### PR TITLE
chore: switch build-mcpb CI job to mcp2mcpb --from-dist (v0.5)

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -174,42 +174,32 @@ jobs:
   build-mcpb:
     name: Build .mcpb Package
     runs-on: ubuntu-latest
-    needs: build
+    needs: [build]
     if: startsWith(github.ref, 'refs/tags/')
 
     steps:
       - uses: actions/checkout@v4
 
-      - uses: astral-sh/setup-uv@v6
+      - name: Download wheel
+        uses: actions/download-artifact@v4
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
-          enable-cache: true
+          name: python-package-distributions
+          path: dist/
 
-      - name: Build .mcpb
-        run: python scripts/build_mcpb.py
-
-      - name: Validate .mcpb
-        run: |
-          python - <<'EOF'
-          import zipfile, json
-          from pathlib import Path
-          mcpb = next(Path("dist").glob("*.mcpb"))
-          with zipfile.ZipFile(mcpb) as z:
-              names = z.namelist()
-              assert "manifest.json" in names
-              assert "server/main.py" in names
-              manifest = json.loads(z.read("manifest.json"))
-              for field in ("manifest_version", "name", "version", "server"):
-                  assert field in manifest
-              assert manifest["server"]["type"] == "uv"
-              assert isinstance(manifest.get("repository"), dict)
-          print(f"✓ {mcpb.name} validated")
-          EOF
+      - name: Build .mcpb bundle
+        uses: Anselmoo/mcp2mcpb@v0.5
+        with:
+          package: mcp-server-analyzer
+          registry: pypi
+          mode: reference
+          from-dist: dist/
+          attach-to-release: 'false'
 
       - uses: actions/upload-artifact@v4
         with:
           name: mcpb-package
           path: dist/*.mcpb
+          if-no-files-found: error
 
   # ============================================================================
   # Docker Image Check (smoke test, no push)

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -187,7 +187,7 @@ jobs:
           path: dist/
 
       - name: Build .mcpb bundle
-        uses: Anselmoo/mcp2mcpb@v0.5
+        uses: Anselmoo/mcp2mcpb@b040babc466902b721e2367d2e5611908c3603d8
         with:
           package: mcp-server-analyzer
           registry: pypi


### PR DESCRIPTION
## Summary

- Replaces the custom `scripts/build_mcpb.py` call + inline validation in the `build-mcpb` CI job with the official `Anselmoo/mcp2mcpb@v0.5` composite action
- Adds a `download-artifact@v4` step to fetch the built wheel into `dist/` before bundling
- Uses `from-dist: dist/` — version is read from the wheel's own METADATA, so releasing v0.3.0 always produces `mcp-server-analyzer-0.3.0.mcpb`
- `scripts/build_mcpb.py` retained for local dev use
- `github-release` job unchanged

## Test plan

- [ ] CI passes the `build-mcpb` job on this PR
- [ ] On a tag push: verify `github-release` attaches the correctly-versioned `.mcpb` to the GitHub Release

🤖 Generated with [Claude Code](https://claude.com/claude-code)