### PR TITLE
feat: add Semgrep, actionlint, and gitleaks analyzers

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -43,6 +43,15 @@ jobs:
       - name: Add node_modules/.bin to PATH
         run: echo "${{ github.workspace }}/node_modules/.bin" >> $GITHUB_PATH
 
+      - name: Install actionlint and gitleaks (Go binaries)
+        run: |
+          mkdir -p "${{ github.workspace }}/.tools"
+          bash <(curl -sSf https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash) 1.7.12 "${{ github.workspace }}/.tools"
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/gitleaks_8.30.1_linux_x64.tar.gz" | tar -xz -C "${{ github.workspace }}/.tools" gitleaks
+
+      - name: Add .tools to PATH
+        run: echo "${{ github.workspace }}/.tools" >> $GITHUB_PATH
+
       - name: Run pre-commit
         run: uv run pre-commit run --all-files --show-diff-on-failure
         env:
@@ -107,6 +116,15 @@ jobs:
 
       - name: Add node_modules/.bin to PATH
         run: echo "${{ github.workspace }}/node_modules/.bin" >> $GITHUB_PATH
+
+      - name: Install actionlint and gitleaks (Go binaries)
+        run: |
+          mkdir -p "${{ github.workspace }}/.tools"
+          bash <(curl -sSf https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash) 1.7.12 "${{ github.workspace }}/.tools"
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/gitleaks_8.30.1_linux_x64.tar.gz" | tar -xz -C "${{ github.workspace }}/.tools" gitleaks
+
+      - name: Add .tools to PATH
+        run: echo "${{ github.workspace }}/.tools" >> $GITHUB_PATH
 
       - name: Run tests with coverage
         env:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,6 +49,36 @@ repos:
         pass_filenames: true
         require_serial: true
 
+  # Security/SAST scanning with Semgrep (falls back to `uvx semgrep` if not
+  # installed locally, matching semgrep-check's own discovery order)
+  - repo: local
+    hooks:
+      - id: semgrep
+        name: semgrep check (security/SAST)
+        entry: bash -c 'command -v semgrep >/dev/null 2>&1 && semgrep --config auto --error --quiet "$@" || uvx semgrep --config auto --error --quiet "$@"' --
+        language: system
+        types: [python]
+        pass_filenames: true
+
+  # GitHub Actions workflow linting with actionlint (requires: actionlint binary)
+  - repo: local
+    hooks:
+      - id: actionlint
+        name: actionlint (GitHub Actions workflows)
+        entry: actionlint
+        language: system
+        files: ^\.github/workflows/.*\.ya?ml$
+
+  # Secret scanning with gitleaks (requires: gitleaks binary)
+  - repo: local
+    hooks:
+      - id: gitleaks
+        name: gitleaks (secret scan)
+        entry: gitleaks dir --redact --no-banner
+        language: system
+        pass_filenames: false
+        always_run: true
+
   # Release policy checks with repo-release-tools
   - repo: https://github.com/Anselmoo/repo-release-tools
     rev: v1.10.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+### Added
+- Add `semgrep-check` MCP tool for security/SAST scanning, with CWE/OWASP metadata (#28)
+- Add `actionlint-check` MCP tool for GitHub Actions workflow linting (#29)
+- Add `gitleaks-scan` MCP tool for secret scanning — always redacts secret values (#30)
+- Add tool documentation for all three in `docs/tools.md`, `docs/index.md`, and `README.md`
+- Add `semgrep`, `actionlint`, and `gitleaks` pre-commit hooks to `.pre-commit-config.yaml`
+
+### CI/CD
+- Install pinned `actionlint` and `gitleaks` release binaries in `lint`/`test` jobs and add them to `PATH`
+- Skip extra CI wiring for Semgrep — it falls back to `uvx semgrep`, already available via `astral-sh/setup-uv@v6`
+
 ## [0.3.0] - 2026-07-01
 ### Changed
 - `ty` pre-commit hook switched from local `uv run ty check` entry to the official `https://github.com/astral-sh/ty-pre-commit` hook at `v0.0.55` — uses `pass_filenames=false` and `always_run=true` for correct whole-project type checking

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,13 @@ uv run rrt release check                       # validate version targets and ch
 - Run `npm ci` before using `biome-check`/`biome-format` MCP tools or the pre-commit Biome hook.
 - `.mcp.json` uses `sh -c "PATH=\"$PWD/node_modules/.bin:$PATH\" uv run mcp-server-analyzer"` to make Biome discoverable in dev mode.
 
+## Semgrep, actionlint, gitleaks
+- None of these three are `pyproject.toml` dependencies — do NOT add `semgrep` there. Semgrep's PyPI package bundles its own MCP integration and pins an exact `mcp` version, which downgrades this project's own `mcp`/`fastmcp` resolution if added as a direct dependency (verified: pulls `mcp` from 1.28.x down to 1.23.3).
+- `SemgrepAnalyzer` mirrors `BiomeAnalyzer`'s discovery pattern: tries `semgrep` on `PATH` first, falls back to `uvx semgrep` — no install step needed if `uv` is available.
+- `semgrep-check`'s default `config="auto"` requires network access to the Semgrep registry and **cannot** be combined with `--metrics=off` (Semgrep rejects that combination outright) — `SemgrepAnalyzer` only appends `--metrics=off` when a non-`"auto"` config is passed.
+- `actionlint`/`gitleaks` are Go binaries with no PyPI/npm equivalent — install via `go install .../actionlint/cmd/actionlint@latest` and `go install .../gitleaks/v8@latest`, or let CI's pinned release-binary download handle it.
+- `gitleaks-scan` always passes `--redact` — this is a security-critical, non-negotiable invariant. Never remove it or make it optional.
+
 ## Dev commands
 ```bash
 uv sync --dev && npm ci                        # full setup

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![Docs](https://img.shields.io/badge/docs-GitHub%20Pages-blue)](https://anselmoo.github.io/mcp-server-analyzer/)
 
 
-A powerful [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server that provides comprehensive Python code analysis using [**Ruff**](https://docs.astral.sh/ruff/) for linting, [**ty**](https://docs.astral.sh/ty/) for type checking, and [**Vulture**](https://github.com/jendrikseipp/vulture) for dead code detection. Perfect for AI assistants, IDEs, and automated code review workflows.
+A powerful [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server that provides comprehensive Python, JavaScript, and TypeScript code analysis and security scanning using [**Ruff**](https://docs.astral.sh/ruff/) for linting, [**ty**](https://docs.astral.sh/ty/) for type checking, [**Vulture**](https://github.com/jendrikseipp/vulture) for dead code detection, [**Biome**](https://biomejs.dev/) for JS/TS linting and formatting, [**Semgrep**](https://semgrep.dev/) for security/SAST scanning, [**actionlint**](https://github.com/rhysd/actionlint) for GitHub Actions workflow linting, and [**gitleaks**](https://github.com/gitleaks/gitleaks) for secret scanning. Perfect for AI assistants, IDEs, and automated code review workflows.
 
 ## 🚀 Quick Start
 
@@ -85,6 +85,9 @@ uv run mcp-server-analyzer
 - **🧠 ty Type Checking**: Fast Python type analysis with rule-based diagnostics
 - **🧹 Dead Code Detection**: Find unused imports, functions, and variables with VULTURE
 - **⚡ Biome JS/TS Analysis**: Fast linting and formatting for JavaScript and TypeScript
+- **🛡️ Semgrep Security Scan**: Security/SAST scanning with CWE/OWASP metadata
+- **✅ actionlint Workflow Linting**: Static analysis for GitHub Actions workflow YAML
+- **🔑 gitleaks Secret Scanning**: Detect hardcoded secrets with redacted results
 - **📊 Quality Scoring**: Combined analysis with quality metrics
 - **🚀 FastMCP Framework**: High-performance MCP server implementation
 - **🐳 Docker Ready**: Multi-architecture containers with security signing
@@ -111,6 +114,9 @@ Explore dead code detection capabilities: **[🧹 VULTURE Analysis Preview](exam
 | `vulture-scan`  | Dead code detection                   | Unused imports, functions, variables |
 | `biome-check`   | Lint JS/TS code with Biome            | Style violations, potential errors   |
 | `biome-format`  | Format JS/TS code with Biome          | Code formatting and consistency      |
+| `semgrep-check` | Security/SAST scan with Semgrep       | Injection, secrets-in-code, CWE/OWASP findings |
+| `actionlint-check` | Lint GitHub Actions workflows      | Invalid expressions, misconfigured steps |
+| `gitleaks-scan` | Secret scanning with gitleaks (redacted) | Hardcoded credentials, API keys, private keys |
 | `analyze-code`  | Combined Ruff + ty + Vulture analysis | Complete code quality assessment     |
 
 ## 🔧 Configuration
@@ -165,7 +171,18 @@ Place `.mcp.json` at your project root:
 - Python 3.13+
 - [uv](https://docs.astral.sh/uv/) (recommended) or pip
 - Node.js 22+ (for Biome JS/TS analysis)
+- Go 1.23+ (only if you want to install actionlint/gitleaks binaries yourself — see below)
 - [Docker](https://docker.com) (optional)
+
+Ruff, ty, and Vulture install automatically via `uv sync`. Biome, Semgrep,
+actionlint, and gitleaks are external tools discovered on `PATH` at runtime;
+each analyzer degrades gracefully (its tool returns "not available") if its
+backing binary is missing, so none of them are hard requirements:
+
+- **Biome**: `npm ci` (project-local) or `npm install -g @biomejs/biome`
+- **Semgrep**: falls back to `uvx semgrep` automatically — no separate install needed if `uv` is available; or `pipx install semgrep`
+- **actionlint**: `go install github.com/rhysd/actionlint/cmd/actionlint@latest` or the [official install script](https://github.com/rhysd/actionlint/blob/main/scripts/download-actionlint.bash)
+- **gitleaks**: `go install github.com/gitleaks/gitleaks/v8@latest` or a [release binary](https://github.com/gitleaks/gitleaks/releases)
 
 ### Setup
 
@@ -227,9 +244,10 @@ The server provides quality scoring based on:
 ## 🔍 Data Handling & Transparency
 
 - **In-memory only**: Code passed to tools is written to a temporary file, analyzed, and the file is deleted immediately — nothing is persisted between calls.
-- **No network calls**: The server makes no outbound network connections during analysis.
-- **No telemetry**: No usage data, analytics, or crash reports are collected.
-- **Subprocess isolation**: ruff, ty, and vulture are invoked with fixed argument lists — no shell expansion or arbitrary command execution.
+- **No network calls by default**: Ruff, ty, Vulture, Biome, actionlint, and gitleaks make no outbound network connections. `semgrep-check` is the one exception — its default `config="auto"` fetches rules from the Semgrep registry over the network; pass an explicit local config (e.g. a rule file path) to run it fully offline.
+- **No telemetry**: `semgrep-check` always passes `--metrics=off` for explicit (non-`"auto"`) configs; Semgrep's own usage metrics are only sent when `config="auto"` resolves rules from the registry (a Semgrep requirement, not something this server can disable). No other tool collects usage data, analytics, or crash reports.
+- **Secrets are always redacted**: `gitleaks-scan` always runs with `--redact` — raw secret values are never returned, only the literal string `"REDACTED"`.
+- **Subprocess isolation**: All backing tools are invoked with fixed argument lists — no shell expansion or arbitrary command execution.
 
 ## 📚 Documentation
 
@@ -240,6 +258,10 @@ The server provides quality scoring based on:
 - **[Ruff Documentation](https://docs.astral.sh/ruff/)** - Python linter and formatter
 - **[ty Documentation](https://docs.astral.sh/ty/)** - Python type checker and language server
 - **[Vulture Documentation](https://github.com/jendrikseipp/vulture)** - Dead code finder
+- **[Biome Documentation](https://biomejs.dev/)** - JS/TS linter and formatter
+- **[Semgrep Documentation](https://semgrep.dev/docs/)** - Security/SAST scanner
+- **[actionlint Documentation](https://github.com/rhysd/actionlint)** - GitHub Actions workflow linter
+- **[gitleaks Documentation](https://github.com/gitleaks/gitleaks)** - Secret scanner
 
 ## 🤝 Contributing
 

--- a/docs/CICD_SETUP.md
+++ b/docs/CICD_SETUP.md
@@ -39,6 +39,86 @@ If Biome is not installed, `biome-check` and `biome-format` raise a `ToolError`
 with the message "biome is not available". All Python analysis tools continue
 to function normally.
 
+## 🛡️ Security/SAST (Semgrep) Prerequisites
+
+The `semgrep-check` MCP tool requires [Semgrep](https://semgrep.dev/) to be
+available at runtime. Semgrep is **not** a project dependency (adding it to
+`pyproject.toml` pins an exact `mcp` version via Semgrep's own bundled MCP
+integration, which would downgrade this project's MCP stack) — it's
+discovered on `PATH`, falling back to `uvx semgrep`.
+
+### Local Development
+
+No install step is required if [uv](https://docs.astral.sh/uv/) is
+available — `semgrep-check` automatically falls back to `uvx semgrep`. To use
+a locally installed `semgrep` instead: `pipx install semgrep`.
+
+### CI/CD
+
+No dedicated CI step is needed — `astral-sh/setup-uv@v6` already provides
+`uvx`, which the analyzer falls back to automatically.
+
+### Graceful Degradation
+
+If neither `semgrep` nor `uvx` is available, `semgrep-check` raises a
+`ToolError` with the message "semgrep is not available". All other tools
+continue to function normally.
+
+## ✅ GitHub Actions (actionlint) Prerequisites
+
+The `actionlint-check` MCP tool requires the [actionlint](https://github.com/rhysd/actionlint)
+Go binary to be available on `PATH`.
+
+### Local Development
+
+Go 1.23+ is required to build from source, or install a release binary
+directly:
+
+```bash
+go install github.com/rhysd/actionlint/cmd/actionlint@latest
+# or
+bash <(curl -sSf https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+```
+
+### CI/CD
+
+The `lint` and `test` jobs install a pinned release binary via the official
+download script and add it to `$GITHUB_PATH`.
+
+### Graceful Degradation
+
+If actionlint is not installed, `actionlint-check` raises a `ToolError` with
+the message "actionlint is not available". All other tools continue to
+function normally.
+
+## 🔑 Secret Scanning (gitleaks) Prerequisites
+
+The `gitleaks-scan` MCP tool requires the [gitleaks](https://github.com/gitleaks/gitleaks)
+Go binary to be available on `PATH`.
+
+### Local Development
+
+Go 1.23+ is required to build from source, or install a release binary
+directly:
+
+```bash
+go install github.com/gitleaks/gitleaks/v8@latest
+# or download a release binary from
+# https://github.com/gitleaks/gitleaks/releases
+```
+
+### CI/CD
+
+The `lint` and `test` jobs download a pinned release binary and add it to
+`$GITHUB_PATH`.
+
+### Graceful Degradation
+
+If gitleaks is not installed, `gitleaks-scan` raises a `ToolError` with the
+message "gitleaks is not available". All other tools continue to function
+normally. Regardless of availability, `gitleaks-scan` always runs with
+`--redact` — raw secret values are never returned by the tool.
+
 ## 🔐 GitHub Repository Settings
 
 ### Required Permissions

--- a/docs/development.md
+++ b/docs/development.md
@@ -5,6 +5,7 @@
 - Python 3.13+
 - [uv](https://docs.astral.sh/uv/)
 - Node.js 22+ (for Biome JS/TS analysis)
+- Go 1.23+ (only if installing actionlint/gitleaks binaries yourself)
 - Docker (optional)
 
 ## Setup
@@ -16,6 +17,13 @@ uv sync --dev
 
 # Install Biome (JS/TS analyzer)
 npm ci
+
+# Semgrep, actionlint, and gitleaks are external tools discovered on PATH;
+# each analyzer degrades gracefully if its binary is missing. Semgrep falls
+# back to `uvx semgrep` automatically. actionlint/gitleaks need a manual
+# install, e.g.:
+go install github.com/rhysd/actionlint/cmd/actionlint@latest
+go install github.com/gitleaks/gitleaks/v8@latest
 ```
 
 ## Common Tasks
@@ -58,7 +66,10 @@ src/mcp_server_analyzer/
     ├── ruff.py          # Ruff linting & formatting
     ├── ty.py            # ty type checking
     ├── vulture.py       # Vulture dead code detection
-    └── biome.py         # Biome JS/TS linting & formatting
+    ├── biome.py         # Biome JS/TS linting & formatting
+    ├── semgrep.py       # Semgrep security/SAST scanning
+    ├── actionlint.py    # actionlint GitHub Actions workflow linting
+    └── gitleaks.py      # gitleaks secret scanning
 tests/
     conftest.py
     test_*.py

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,7 @@
 [![PyPI version](https://badge.fury.io/py/mcp-server-analyzer.svg)](https://badge.fury.io/py/mcp-server-analyzer)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-A [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server providing comprehensive Python code analysis via [**Ruff**](https://docs.astral.sh/ruff/) linting, [**ty**](https://docs.astral.sh/ty/) type checking, and [**Vulture**](https://github.com/jendrikseipp/vulture) dead code detection.
+A [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server providing comprehensive Python, JavaScript, and TypeScript code analysis and security scanning via [**Ruff**](https://docs.astral.sh/ruff/) linting, [**ty**](https://docs.astral.sh/ty/) type checking, [**Vulture**](https://github.com/jendrikseipp/vulture) dead code detection, [**Biome**](https://biomejs.dev/) JS/TS linting and formatting, [**Semgrep**](https://semgrep.dev/) security/SAST scanning, [**actionlint**](https://github.com/rhysd/actionlint) GitHub Actions workflow linting, and [**gitleaks**](https://github.com/gitleaks/gitleaks) secret scanning.
 
 ## Quick Start
 
@@ -96,14 +96,18 @@ A [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server provid
 | **Vulture dead code** | Unused imports, functions, variables |
 | **Biome JS/TS linting** | Style violations, potential errors, auto-fix hints |
 | **Biome JS/TS formatting** | Code formatting and consistency |
+| **Semgrep security scan** | SAST findings with CWE/OWASP metadata |
+| **actionlint workflow linting** | GitHub Actions workflow YAML validation |
+| **gitleaks secret scanning** | Hardcoded secret detection (redacted results) |
 | **Combined analysis** | Quality score (0-100) across all tools |
 | **CI output formats** | json, gitlab, github, sarif |
 
 ## Data Handling
 
 - Code is written to a **temporary file**, analyzed, then **immediately deleted** — nothing is persisted.
-- The server makes **no outbound network calls** during analysis.
-- No telemetry or usage data is collected.
+- The server makes **no outbound network calls** during analysis, except `semgrep-check`'s default `config="auto"`, which fetches rules from the Semgrep registry — pass an explicit local config to run it fully offline.
+- No telemetry or usage data is collected, except Semgrep's own usage metrics when `config="auto"` resolves rules from the registry (a Semgrep requirement, not disableable by this server).
+- `gitleaks-scan` always redacts secret values — raw secrets are never returned.
 
 ## Available Tools
 
@@ -118,4 +122,7 @@ See the [Tools Reference](tools.md) for full parameter documentation.
 | `vulture-scan` | Dead code detection |
 | `biome-check` | Lint JS/TS code |
 | `biome-format` | Format JS/TS code |
+| `semgrep-check` | Security/SAST scan |
+| `actionlint-check` | Lint GitHub Actions workflows |
+| `gitleaks-scan` | Secret scanning (redacted) |
 | `analyze-code` | Combined analysis + score |

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,6 +1,6 @@
 # Tools Reference
 
-All tools accept Python source code as a string and return structured Pydantic models serialized to JSON.
+All tools accept source code as a string and return structured Pydantic models serialized to JSON.
 
 ---
 
@@ -207,6 +207,114 @@ Format JavaScript/TypeScript code using [Biome](https://biomejs.dev/).
 
 ---
 
+## `semgrep-check`
+
+Scan code for security issues using [Semgrep](https://semgrep.dev/) (SAST).
+
+> **Requires Semgrep:** not a project dependency — uses `semgrep` if it's on `PATH`, otherwise falls back to `uvx semgrep` (no separate install needed if `uv`/`uvx` is available).
+
+**Parameters**
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `code` | `string` | Yes | — | Source code to scan |
+| `config` | `string` | No | `"auto"` | Semgrep ruleset (`"auto"`, `"p/security-audit"`, or a local rule file/path). `"auto"` calls the Semgrep registry over the network; any other value runs fully offline with `--metrics=off`. |
+| `filename` | `string` | No | `"code.py"` | Virtual filename — controls the file suffix/parser used |
+
+**Returns** `SemgrepScanResult`
+
+```json
+{
+  "issues": [
+    {
+      "check_id": "python.lang.security.audit.subprocess-shell-true",
+      "line": 5,
+      "column": 38,
+      "end_line": 5,
+      "end_column": 42,
+      "severity": "ERROR",
+      "message": "Found 'subprocess' function 'run' with 'shell=True'.",
+      "cwe": ["CWE-78: Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')"],
+      "owasp": ["A03:2021 - Injection"]
+    }
+  ],
+  "total_issues": 1,
+  "error_count": 1,
+  "warning_count": 0
+}
+```
+
+---
+
+## `actionlint-check`
+
+Lint a GitHub Actions workflow YAML file using [actionlint](https://github.com/rhysd/actionlint).
+
+> **Requires actionlint:** install the binary, e.g. `go install github.com/rhysd/actionlint/cmd/actionlint@latest` or via the [official install script](https://github.com/rhysd/actionlint/blob/main/scripts/download-actionlint.bash).
+
+**Parameters**
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `code` | `string` | Yes | — | Workflow YAML source to lint |
+| `filename` | `string` | No | `"workflow.yml"` | Virtual filename reported in issue locations |
+
+**Returns** `ActionlintCheckResult`
+
+```json
+{
+  "issues": [
+    {
+      "line": 8,
+      "column": 31,
+      "end_column": 32,
+      "kind": "expression",
+      "message": "unexpected end of input while parsing variable access, function call, null, bool, int, float or string",
+      "snippet": "        if: ${{ badcondition( }}\n                              ^~"
+    }
+  ],
+  "total_issues": 1
+}
+```
+
+---
+
+## `gitleaks-scan`
+
+Scan code for hardcoded secrets using [gitleaks](https://github.com/gitleaks/gitleaks). Secret values are always redacted — `secret` and `match` are always the literal string `"REDACTED"`, never the actual matched text.
+
+> **Requires gitleaks:** install the binary, e.g. `go install github.com/gitleaks/gitleaks/v8@latest` or download a [release binary](https://github.com/gitleaks/gitleaks/releases).
+
+**Parameters**
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `code` | `string` | Yes | — | Source code to scan |
+| `filename` | `string` | No | `"code.txt"` | Virtual filename reported against each finding |
+
+**Returns** `GitleaksScanResult`
+
+```json
+{
+  "findings": [
+    {
+      "rule_id": "private-key",
+      "description": "Identified a Private Key, which may compromise cryptographic security and sensitive data encryption.",
+      "file": "key.pem",
+      "start_line": 1,
+      "end_line": 28,
+      "start_column": 1,
+      "end_column": 26,
+      "secret": "REDACTED",
+      "match": "REDACTED"
+    }
+  ],
+  "total_findings": 1
+}
+```
+
+---
+
 ## `analyze-code`
 
 Run Ruff, ty, and Vulture together and return a combined quality score.
@@ -259,7 +367,7 @@ Score is clamped to `[0, 100]`.
 All tools raise a `ToolError` (MCP structured error) when:
 
 - Input `code` is empty or whitespace-only.
-- The backing tool (ruff/ty/vulture) is not installed.
+- The backing tool (ruff/ty/vulture/biome/semgrep/actionlint/gitleaks) is not installed.
 - The tool process exits with an unexpected error.
 
 MCP clients receive the error as a structured response with `isError: true`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 [project]
 name = "mcp-server-analyzer"
 version = "0.3.0"
-description = "MCP server for Python, JavaScript, and TypeScript code analysis with Ruff, ty, Vulture, and Biome"
+description = "MCP server for Python, JavaScript, and TypeScript code analysis and security scanning with Ruff, ty, Vulture, Biome, Semgrep, actionlint, and gitleaks"
 readme = "README.md"
 license = { text = "MIT" }
 requires-python = ">=3.13"
@@ -22,6 +22,12 @@ keywords = [
     "linting",
     "type-checking",
     "static-analysis",
+    "semgrep",
+    "actionlint",
+    "gitleaks",
+    "security",
+    "sast",
+    "secret-scanning",
 ]
 classifiers = [
     "Development Status :: 4 - Beta",

--- a/src/mcp_server_analyzer/analyzers/__init__.py
+++ b/src/mcp_server_analyzer/analyzers/__init__.py
@@ -1,8 +1,19 @@
-"""Analyzers package for Ruff, ty, Vulture, and Biome integration."""
+"""Analyzers package for Ruff, ty, Vulture, Biome, Semgrep, actionlint, and gitleaks integration."""
 
+from .actionlint import ActionlintAnalyzer
 from .biome import BiomeAnalyzer
+from .gitleaks import GitleaksAnalyzer
 from .ruff import RuffAnalyzer
+from .semgrep import SemgrepAnalyzer
 from .ty import TyAnalyzer
 from .vulture import VultureAnalyzer
 
-__all__ = ["BiomeAnalyzer", "RuffAnalyzer", "TyAnalyzer", "VultureAnalyzer"]
+__all__ = [
+    "ActionlintAnalyzer",
+    "BiomeAnalyzer",
+    "GitleaksAnalyzer",
+    "RuffAnalyzer",
+    "SemgrepAnalyzer",
+    "TyAnalyzer",
+    "VultureAnalyzer",
+]

--- a/src/mcp_server_analyzer/analyzers/actionlint.py
+++ b/src/mcp_server_analyzer/analyzers/actionlint.py
@@ -1,0 +1,95 @@
+"""actionlint integration for GitHub Actions workflow linting."""
+
+import json
+import subprocess
+
+from mcp_server_analyzer.models import ActionlintCheckResult, ActionlintIssue
+
+
+class ActionlintAnalyzer:
+    """Handles actionlint-based GitHub Actions workflow linting."""
+
+    def __init__(self) -> None:
+        """Initialize ActionlintAnalyzer by checking the actionlint binary is available."""
+        self._check_actionlint_installation()
+
+    def _check_actionlint_installation(self) -> None:
+        """Verify that actionlint is installed and accessible."""
+        try:
+            subprocess.run(
+                ["actionlint", "-version"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                check=True,
+            )
+        except (
+            subprocess.CalledProcessError,
+            FileNotFoundError,
+            subprocess.TimeoutExpired,
+        ) as e:
+            raise RuntimeError(f"actionlint is not available: {e}") from e
+
+    def check_workflow(
+        self, code: str, filename: str = "workflow.yml"
+    ) -> ActionlintCheckResult:
+        """
+        Lint a GitHub Actions workflow YAML file using actionlint via stdin.
+
+        Args:
+            code: Workflow YAML source to lint
+            filename: Virtual filename reported in issue locations
+
+        Returns:
+            ActionlintCheckResult containing workflow issues and counts
+
+        """
+        cmd = [
+            "actionlint",
+            "-stdin-filename",
+            filename,
+            "-format",
+            "{{json .}}",
+            "-",
+        ]
+
+        try:
+            result = subprocess.run(
+                cmd,
+                input=code,
+                capture_output=True,
+                text=True,
+                timeout=30,
+                check=False,
+            )
+        except subprocess.TimeoutExpired:
+            raise RuntimeError("actionlint check timed out") from None
+        except (FileNotFoundError, PermissionError) as e:
+            raise RuntimeError(f"Failed to run actionlint: {e}") from e
+
+        # 0 = success/no problems, 1 = success/problems found; 2 = invalid CLI
+        # option, 3 = fatal error.
+        if result.returncode not in (0, 1):
+            raise RuntimeError(
+                f"actionlint check failed: {result.stderr.strip() or 'unknown error'}"
+            )
+
+        stdout = result.stdout.strip()
+        try:
+            raw_issues = json.loads(stdout) if stdout else []
+        except json.JSONDecodeError as e:
+            raise RuntimeError(f"Failed to parse actionlint output: {e}") from e
+
+        issues = [
+            ActionlintIssue(
+                line=item.get("line", 0),
+                column=item.get("column", 0),
+                end_column=item.get("end_column"),
+                kind=item.get("kind", ""),
+                message=item.get("message", ""),
+                snippet=item.get("snippet"),
+            )
+            for item in raw_issues
+        ]
+
+        return ActionlintCheckResult(issues=issues, total_issues=len(issues))

--- a/src/mcp_server_analyzer/analyzers/gitleaks.py
+++ b/src/mcp_server_analyzer/analyzers/gitleaks.py
@@ -1,0 +1,108 @@
+"""gitleaks integration for secret scanning."""
+
+import json
+import subprocess
+import tempfile
+from pathlib import Path
+
+from mcp_server_analyzer.models import GitleaksFinding, GitleaksScanResult
+
+
+class GitleaksAnalyzer:
+    """Handles gitleaks-based secret scanning. Secret values are always redacted."""
+
+    def __init__(self) -> None:
+        """Initialize the gitleaks analyzer."""
+        self._check_gitleaks_installation()
+
+    def _check_gitleaks_installation(self) -> None:
+        """Verify that gitleaks is installed and accessible."""
+        try:
+            subprocess.run(
+                ["gitleaks", "version"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                check=True,
+            )
+        except (
+            subprocess.CalledProcessError,
+            FileNotFoundError,
+            subprocess.TimeoutExpired,
+        ) as e:
+            raise RuntimeError(f"gitleaks is not available: {e}") from e
+
+    def scan_code(self, code: str, filename: str = "code.txt") -> GitleaksScanResult:
+        """
+        Scan code for hardcoded secrets using gitleaks.
+
+        Args:
+            code: Source code to scan
+            filename: Virtual filename reported against each finding
+
+        Returns:
+            GitleaksScanResult containing findings with secret values redacted
+
+        """
+        temp_file: Path | None = None
+        try:
+            suffix = Path(filename).suffix or ".txt"
+            with tempfile.NamedTemporaryFile(
+                mode="w", suffix=suffix, delete=False
+            ) as f:
+                f.write(code)
+                temp_file = Path(f.name)
+
+            cmd = [
+                "gitleaks",
+                "dir",
+                "--redact",
+                "--report-format",
+                "json",
+                "--report-path",
+                "-",
+                "--no-banner",
+                str(temp_file),
+            ]
+
+            result = subprocess.run(
+                cmd, capture_output=True, text=True, timeout=30, check=False
+            )
+
+            # 0 = no leaks found, 1 = leaks found; anything else is a real failure.
+            if result.returncode not in (0, 1):
+                error_msg = (
+                    result.stderr.strip()
+                    or f"Unknown gitleaks error (exit code {result.returncode})"
+                )
+                raise RuntimeError(f"gitleaks scan failed: {error_msg}")
+
+            stdout = result.stdout.strip()
+            try:
+                raw_findings = json.loads(stdout) if stdout else []
+            except json.JSONDecodeError as e:
+                raise RuntimeError(f"Failed to parse gitleaks output: {e}") from e
+
+            findings = [
+                GitleaksFinding(
+                    rule_id=item.get("RuleID", ""),
+                    description=item.get("Description", ""),
+                    file=filename,
+                    start_line=item.get("StartLine", 0),
+                    end_line=item.get("EndLine", 0),
+                    start_column=item.get("StartColumn", 0),
+                    end_column=item.get("EndColumn", 0),
+                    secret=item.get("Secret", "REDACTED"),
+                    match=item.get("Match", "REDACTED"),
+                )
+                for item in raw_findings
+            ]
+
+            return GitleaksScanResult(findings=findings, total_findings=len(findings))
+        except subprocess.TimeoutExpired:
+            raise RuntimeError("gitleaks scan timed out") from None
+        except (FileNotFoundError, PermissionError) as e:
+            raise RuntimeError(f"Failed to run gitleaks: {e}") from e
+        finally:
+            if temp_file is not None:
+                temp_file.unlink(missing_ok=True)

--- a/src/mcp_server_analyzer/analyzers/semgrep.py
+++ b/src/mcp_server_analyzer/analyzers/semgrep.py
@@ -1,0 +1,179 @@
+"""Semgrep integration for security/SAST scanning."""
+
+import json
+import subprocess
+import tempfile
+from pathlib import Path
+
+from mcp_server_analyzer.models import SemgrepIssue, SemgrepScanResult
+
+_SEMGREP_ERRORS = (
+    subprocess.CalledProcessError,
+    FileNotFoundError,
+    subprocess.TimeoutExpired,
+)
+
+
+class SemgrepAnalyzer:
+    """Handles Semgrep-based security/SAST scanning."""
+
+    def __init__(self) -> None:
+        """Initialize SemgrepAnalyzer by discovering the semgrep command."""
+        self._semgrep_cmd: list[str] = self._find_semgrep_cmd()
+
+    def _find_semgrep_cmd(self) -> list[str]:
+        """
+        Discover which semgrep command is available.
+
+        Tries ["semgrep"] first; falls back to ["uvx", "semgrep"] so semgrep
+        doesn't have to be a pinned project dependency (semgrep bundles its own
+        MCP integration and pins an exact `mcp` version, which would otherwise
+        downgrade this project's own MCP stack). Raises RuntimeError if neither
+        is found.
+        """
+        try:
+            subprocess.run(
+                ["semgrep", "--version"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                check=True,
+            )
+        except _SEMGREP_ERRORS:
+            pass
+        else:
+            return ["semgrep"]
+
+        try:
+            subprocess.run(
+                ["uvx", "semgrep", "--version"],
+                capture_output=True,
+                text=True,
+                timeout=30,
+                check=True,
+            )
+        except _SEMGREP_ERRORS as e:
+            raise RuntimeError(
+                f"Semgrep is not available: neither 'semgrep' nor 'uvx semgrep' found: {e}"
+            ) from e
+        else:
+            return ["uvx", "semgrep"]
+
+    def check_code(
+        self, code: str, config: str = "auto", filename: str = "code.py"
+    ) -> SemgrepScanResult:
+        """
+        Scan code for security issues using Semgrep.
+
+        Args:
+            code: Source code to scan
+            config: Semgrep ruleset (e.g. "auto", "p/security-audit", or a local path).
+                "auto" pulls rules from the Semgrep registry over the network.
+            filename: Virtual filename used to pick the correct file suffix/parser
+
+        Returns:
+            SemgrepScanResult containing security findings and counts
+
+        """
+        temp_file: Path | None = None
+        try:
+            suffix = Path(filename).suffix or ".py"
+            with tempfile.NamedTemporaryFile(
+                mode="w", suffix=suffix, delete=False
+            ) as f:
+                f.write(code)
+                temp_file = Path(f.name)
+
+            cmd = [
+                *self._semgrep_cmd,
+                "--config",
+                config,
+                "--json",
+                "--quiet",
+                "--disable-version-check",
+                str(temp_file),
+            ]
+            # --metrics=off cannot be combined with --config auto (semgrep requires
+            # metrics to resolve the auto ruleset); only disable metrics for explicit
+            # configs, where no registry auto-resolution is involved.
+            if config != "auto":
+                cmd.append("--metrics=off")
+
+            result = subprocess.run(
+                cmd, capture_output=True, text=True, timeout=60, check=False
+            )
+
+            # semgrep exits 0 whether or not findings are present (--error is not
+            # passed); any other exit code indicates a real failure (bad config,
+            # crash, etc).
+            if result.returncode != 0:
+                error_msg = (
+                    result.stderr.strip()
+                    or result.stdout.strip()
+                    or f"Unknown semgrep error (exit code {result.returncode})"
+                )
+                raise RuntimeError(f"Semgrep check failed: {error_msg}")
+
+            try:
+                output = json.loads(result.stdout) if result.stdout.strip() else {}
+            except json.JSONDecodeError as e:
+                raise RuntimeError(f"Failed to parse Semgrep output: {e}") from e
+
+            issues = self._parse_results(output.get("results", []), str(temp_file))
+
+            return SemgrepScanResult(
+                issues=issues,
+                total_issues=len(issues),
+                error_count=sum(1 for i in issues if i.severity == "ERROR"),
+                warning_count=sum(1 for i in issues if i.severity == "WARNING"),
+            )
+        except subprocess.TimeoutExpired:
+            raise RuntimeError("Semgrep check timed out") from None
+        except (FileNotFoundError, PermissionError) as e:
+            raise RuntimeError(f"Failed to run Semgrep: {e}") from e
+        finally:
+            if temp_file is not None:
+                temp_file.unlink(missing_ok=True)
+
+    def _parse_results(
+        self, results: list[dict], temp_filename: str
+    ) -> list[SemgrepIssue]:
+        """
+        Parse Semgrep's JSON "results" list into structured issues.
+
+        Args:
+            results: Raw "results" list from Semgrep's JSON output
+            temp_filename: Temporary file name to filter out unrelated results
+
+        Returns:
+            List of SemgrepIssue objects
+
+        """
+        issues: list[SemgrepIssue] = []
+        temp_path_resolved = str(Path(temp_filename).resolve())
+
+        for item in results:
+            path = item.get("path")
+            if path is not None and str(Path(path).resolve()) != temp_path_resolved:
+                continue
+
+            start = item.get("start") or {}
+            end = item.get("end") or {}
+            extra = item.get("extra") or {}
+            metadata = extra.get("metadata") or {}
+
+            issues.append(
+                SemgrepIssue(
+                    check_id=item.get("check_id", ""),
+                    line=start.get("line", 0),
+                    column=start.get("col", 0),
+                    end_line=end.get("line", 0),
+                    end_column=end.get("col", 0),
+                    severity=extra.get("severity", "INFO"),
+                    message=extra.get("message", ""),
+                    cwe=metadata.get("cwe", []),
+                    owasp=metadata.get("owasp", []),
+                )
+            )
+
+        return issues

--- a/src/mcp_server_analyzer/models.py
+++ b/src/mcp_server_analyzer/models.py
@@ -128,6 +128,76 @@ class RuffCICheckResult(BaseModel):
     success: bool = Field(description="Whether the check completed without errors")
 
 
+class SemgrepIssue(BaseModel):
+    """Represents a single Semgrep security/SAST finding."""
+
+    check_id: str = Field(description="Semgrep rule identifier that matched")
+    line: int = Field(description="Line number where the finding starts")
+    column: int = Field(description="Column number where the finding starts")
+    end_line: int = Field(description="Line number where the finding ends")
+    end_column: int = Field(description="Column number where the finding ends")
+    severity: str = Field(description="Semgrep severity (ERROR, WARNING, INFO)")
+    message: str = Field(description="Human-readable description of the finding")
+    cwe: list[str] = Field(
+        default_factory=list, description="Associated CWE identifiers, if any"
+    )
+    owasp: list[str] = Field(
+        default_factory=list, description="Associated OWASP Top 10 categories, if any"
+    )
+
+
+class SemgrepScanResult(BaseModel):
+    """Result of a Semgrep security scan operation."""
+
+    issues: list[SemgrepIssue] = Field(description="List of security findings")
+    total_issues: int = Field(description="Total number of findings")
+    error_count: int = Field(description="Number of ERROR-severity findings")
+    warning_count: int = Field(description="Number of WARNING-severity findings")
+
+
+class ActionlintIssue(BaseModel):
+    """Represents a single actionlint GitHub Actions workflow issue."""
+
+    line: int = Field(description="Line number where the issue occurs")
+    column: int = Field(description="Column number where the issue occurs")
+    end_column: int | None = Field(None, description="End column number, if reported")
+    kind: str = Field(description="actionlint rule/check category")
+    message: str = Field(description="Human-readable description of the issue")
+    snippet: str | None = Field(
+        None, description="Source snippet showing the issue location"
+    )
+
+
+class ActionlintCheckResult(BaseModel):
+    """Result of an actionlint workflow check operation."""
+
+    issues: list[ActionlintIssue] = Field(description="List of workflow issues found")
+    total_issues: int = Field(description="Total number of issues")
+
+
+class GitleaksFinding(BaseModel):
+    """Represents a single gitleaks secret-scanning finding. Secret values are always redacted."""
+
+    rule_id: str = Field(description="gitleaks rule identifier that matched")
+    description: str = Field(description="Human-readable description of the rule")
+    file: str = Field(description="Source filename the finding was reported against")
+    start_line: int = Field(description="Line number where the secret starts")
+    end_line: int = Field(description="Line number where the secret ends")
+    start_column: int = Field(description="Column number where the secret starts")
+    end_column: int = Field(description="Column number where the secret ends")
+    secret: str = Field(
+        description="Redacted secret value — always 'REDACTED', raw secrets are never returned"
+    )
+    match: str = Field(description="Redacted matched line context — always 'REDACTED'")
+
+
+class GitleaksScanResult(BaseModel):
+    """Result of a gitleaks secret scan operation."""
+
+    findings: list[GitleaksFinding] = Field(description="List of secret findings")
+    total_findings: int = Field(description="Total number of findings")
+
+
 class AnalysisSummary(BaseModel):
     """Summary statistics from a combined code analysis."""
 

--- a/src/mcp_server_analyzer/server.py
+++ b/src/mcp_server_analyzer/server.py
@@ -11,19 +11,25 @@ from fastmcp.exceptions import ToolError
 from mcp.types import ToolAnnotations
 
 from mcp_server_analyzer.analyzers import (
+    ActionlintAnalyzer,
     BiomeAnalyzer,
+    GitleaksAnalyzer,
     RuffAnalyzer,
+    SemgrepAnalyzer,
     TyAnalyzer,
     VultureAnalyzer,
 )
 from mcp_server_analyzer.models import (
+    ActionlintCheckResult,
     AnalysisResult,
     AnalysisSummary,
     BiomeCheckResult,
     BiomeFormatResult,
+    GitleaksScanResult,
     RuffCheckResult,
     RuffCICheckResult,
     RuffFormatResult,
+    SemgrepScanResult,
     TyCheckResult,
     VultureScanResult,
 )
@@ -66,6 +72,30 @@ except RuntimeError as e:  # pragma: no cover
     biome_analyzer = None
     biome_available = False
 
+try:
+    semgrep_analyzer: SemgrepAnalyzer | None = SemgrepAnalyzer()
+    semgrep_available = True
+except RuntimeError as e:  # pragma: no cover
+    logger.warning("semgrep not available: %s", e)
+    semgrep_analyzer = None
+    semgrep_available = False
+
+try:
+    actionlint_analyzer: ActionlintAnalyzer | None = ActionlintAnalyzer()
+    actionlint_available = True
+except RuntimeError as e:  # pragma: no cover
+    logger.warning("actionlint not available: %s", e)
+    actionlint_analyzer = None
+    actionlint_available = False
+
+try:
+    gitleaks_analyzer: GitleaksAnalyzer | None = GitleaksAnalyzer()
+    gitleaks_available = True
+except RuntimeError as e:  # pragma: no cover
+    logger.warning("gitleaks not available: %s", e)
+    gitleaks_analyzer = None
+    gitleaks_available = False
+
 
 # ─── Resources ────────────────────────────────────────────────────────────────
 
@@ -79,7 +109,7 @@ def get_overview() -> str:
     """Overview of available analyzers and tools."""
     return (
         "# Python Analyzer MCP Server\n\n"
-        "Provides three complementary static-analysis tools:\n\n"
+        "Provides complementary static-analysis and security-scanning tools:\n\n"
         "| Tool | Purpose | Decorator |\n"
         "|------|---------|----------|\n"
         "| `ruff-check` | Lint for style & errors | `@mcp.tool` |\n"
@@ -89,6 +119,9 @@ def get_overview() -> str:
         "| `vulture-scan` | Dead code detection | `@mcp.tool` |\n"
         "| `biome-check`  | Lint JS/TS for errors | `@mcp.tool` |\n"
         "| `biome-format` | Format JS/TS code     | `@mcp.tool` |\n"
+        "| `semgrep-check` | Security/SAST scanning | `@mcp.tool` |\n"
+        "| `actionlint-check` | Lint GitHub Actions workflows | `@mcp.tool` |\n"
+        "| `gitleaks-scan` | Secret scanning (redacted) | `@mcp.tool` |\n"
         "| `analyze-code` | Combined analysis + score | `@mcp.tool` |\n\n"
         "## Quality Score\n"
         "The `analyze-code` tool produces a 0-100 quality score:\n"
@@ -312,6 +345,99 @@ def biome_format(code: str, filename: str = "code.ts") -> BiomeFormatResult:
         return biome_analyzer.format_code(code, filename)
     except Exception as e:
         raise ToolError(f"Biome format failed: {e!s}") from e
+
+
+@mcp.tool(
+    name="semgrep-check",
+    tags={"security", "sast", "semgrep"},
+    annotations=ToolAnnotations(readOnlyHint=True, idempotentHint=True),
+)
+def semgrep_check(
+    code: str, config: str = "auto", filename: str = "code.py"
+) -> SemgrepScanResult:
+    """
+    Scan code for security issues using Semgrep (SAST).
+
+    Args:
+        code: Source code to scan
+        config: Semgrep ruleset (e.g. "auto", "p/security-audit", or a local path).
+            "auto" pulls rules from the Semgrep registry over the network.
+        filename: Virtual filename used to pick the correct file suffix/parser
+
+    Returns:
+        SemgrepScanResult containing security findings, counts, and metadata
+
+    """
+    if not code.strip():
+        raise ToolError("Input code must not be empty.")
+    if not semgrep_available or semgrep_analyzer is None:
+        raise ToolError("semgrep is not available — please install the semgrep package")
+    try:
+        return semgrep_analyzer.check_code(code, config, filename)
+    except Exception as e:
+        raise ToolError(f"Semgrep check failed: {e!s}") from e
+
+
+@mcp.tool(
+    name="actionlint-check",
+    tags={"linting", "actionlint", "github-actions", "ci"},
+    annotations=ToolAnnotations(readOnlyHint=True, idempotentHint=True),
+)
+def actionlint_check(
+    code: str, filename: str = "workflow.yml"
+) -> ActionlintCheckResult:
+    """
+    Lint a GitHub Actions workflow YAML file using actionlint.
+
+    Args:
+        code: Workflow YAML source to lint
+        filename: Virtual filename reported in issue locations
+
+    Returns:
+        ActionlintCheckResult containing workflow issues and counts
+
+    """
+    if not code.strip():
+        raise ToolError("Input code must not be empty.")
+    if not actionlint_available or actionlint_analyzer is None:
+        raise ToolError(
+            "actionlint is not available — install it "
+            "(e.g. `go install github.com/rhysd/actionlint/cmd/actionlint@latest`)"
+        )
+    try:
+        return actionlint_analyzer.check_workflow(code, filename)
+    except Exception as e:
+        raise ToolError(f"actionlint check failed: {e!s}") from e
+
+
+@mcp.tool(
+    name="gitleaks-scan",
+    tags={"security", "secrets", "gitleaks"},
+    annotations=ToolAnnotations(readOnlyHint=True, idempotentHint=True),
+)
+def gitleaks_scan(code: str, filename: str = "code.txt") -> GitleaksScanResult:
+    """
+    Scan code for hardcoded secrets using gitleaks. Secret values are always redacted.
+
+    Args:
+        code: Source code to scan
+        filename: Virtual filename reported against each finding
+
+    Returns:
+        GitleaksScanResult containing findings with secret values redacted
+
+    """
+    if not code.strip():
+        raise ToolError("Input code must not be empty.")
+    if not gitleaks_available or gitleaks_analyzer is None:
+        raise ToolError(
+            "gitleaks is not available — install it "
+            "(e.g. `go install github.com/gitleaks/gitleaks/v8@latest`)"
+        )
+    try:
+        return gitleaks_analyzer.scan_code(code, filename)
+    except Exception as e:
+        raise ToolError(f"gitleaks scan failed: {e!s}") from e
 
 
 def _get_ruff_result(code: str, config_path: str | None) -> RuffCheckResult:

--- a/tests/fixtures/semgrep_rules.yml
+++ b/tests/fixtures/semgrep_rules.yml
@@ -1,0 +1,7 @@
+rules:
+  - id: no-eval
+    patterns:
+      - pattern: eval(...)
+    message: Avoid eval() - arbitrary code execution risk
+    languages: [python]
+    severity: ERROR

--- a/tests/test_actionlint_analyzer.py
+++ b/tests/test_actionlint_analyzer.py
@@ -1,0 +1,209 @@
+"""Unit tests for ActionlintAnalyzer using monkeypatching (no real actionlint needed)."""
+
+import json
+import subprocess
+from typing import Any
+
+import pytest
+
+from mcp_server_analyzer.analyzers.actionlint import ActionlintAnalyzer
+
+
+class FakeCompletedProcess:
+    def __init__(self, returncode: int, stdout: str = "", stderr: str = "") -> None:
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+# ── _check_actionlint_installation ──────────────────────────────────────────
+
+
+def test_check_installation_ok(monkeypatch: Any) -> None:
+    monkeypatch.setattr(
+        subprocess, "run", lambda *a, **k: FakeCompletedProcess(0, "v1.7.12")
+    )
+    ActionlintAnalyzer()
+
+
+def test_check_installation_raises_on_called_process_error(monkeypatch: Any) -> None:
+    def fake_run(*args: Any, **kwargs: Any) -> FakeCompletedProcess:
+        raise subprocess.CalledProcessError(1, "actionlint")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    with pytest.raises(RuntimeError, match="actionlint is not available"):
+        ActionlintAnalyzer()
+
+
+def test_check_installation_raises_on_file_not_found(monkeypatch: Any) -> None:
+    def fake_run(*args: Any, **kwargs: Any) -> FakeCompletedProcess:
+        raise FileNotFoundError("not found")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    with pytest.raises(RuntimeError, match="actionlint is not available"):
+        ActionlintAnalyzer()
+
+
+def test_check_installation_raises_on_timeout(monkeypatch: Any) -> None:
+    def fake_run(*args: Any, **kwargs: Any) -> FakeCompletedProcess:
+        raise subprocess.TimeoutExpired("actionlint", 10)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    with pytest.raises(RuntimeError, match="actionlint is not available"):
+        ActionlintAnalyzer()
+
+
+# ── check_workflow ───────────────────────────────────────────────────────────
+
+
+def test_check_workflow_no_issues(monkeypatch: Any) -> None:
+    responses = [
+        FakeCompletedProcess(0, "v1.7.12"),
+        FakeCompletedProcess(0, "[]"),
+    ]
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: responses.pop(0))
+    analyzer = ActionlintAnalyzer()
+    result = analyzer.check_workflow("on: push\njobs: {}\n")
+    assert result.total_issues == 0
+    assert result.issues == []
+
+
+def test_check_workflow_with_issues(monkeypatch: Any) -> None:
+    issue = {
+        "message": "unexpected end of input while parsing",
+        "filepath": "workflow.yml",
+        "line": 8,
+        "column": 31,
+        "kind": "expression",
+        "snippet": "        if: ${{ badcondition( }}\n                              ^~",
+        "end_column": 32,
+    }
+    responses = [
+        FakeCompletedProcess(0, "v1.7.12"),
+        FakeCompletedProcess(1, json.dumps([issue])),
+    ]
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: responses.pop(0))
+    analyzer = ActionlintAnalyzer()
+    result = analyzer.check_workflow("on: push\n")
+    assert result.total_issues == 1
+    found = result.issues[0]
+    assert found.line == 8
+    assert found.column == 31
+    assert found.end_column == 32
+    assert found.kind == "expression"
+    assert "unexpected end of input" in found.message
+    assert found.snippet is not None
+
+
+def test_check_workflow_missing_optional_fields(monkeypatch: Any) -> None:
+    issue = {"message": "some error", "line": 1, "column": 1, "kind": "syntax-check"}
+    responses = [
+        FakeCompletedProcess(0, "v1.7.12"),
+        FakeCompletedProcess(1, json.dumps([issue])),
+    ]
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: responses.pop(0))
+    analyzer = ActionlintAnalyzer()
+    result = analyzer.check_workflow("on: push\n")
+    assert result.total_issues == 1
+    assert result.issues[0].end_column is None
+    assert result.issues[0].snippet is None
+
+
+def test_check_workflow_empty_stdout(monkeypatch: Any) -> None:
+    responses = [
+        FakeCompletedProcess(0, "v1.7.12"),
+        FakeCompletedProcess(0, ""),
+    ]
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: responses.pop(0))
+    analyzer = ActionlintAnalyzer()
+    result = analyzer.check_workflow("on: push\n")
+    assert result.total_issues == 0
+
+
+def test_check_workflow_invalid_option_exit_code(monkeypatch: Any) -> None:
+    responses = [
+        FakeCompletedProcess(0, "v1.7.12"),
+        FakeCompletedProcess(2, "", "flag provided but not defined"),
+    ]
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: responses.pop(0))
+    analyzer = ActionlintAnalyzer()
+    with pytest.raises(RuntimeError, match="actionlint check failed"):
+        analyzer.check_workflow("on: push\n")
+
+
+def test_check_workflow_fatal_error_exit_code(monkeypatch: Any) -> None:
+    responses = [
+        FakeCompletedProcess(0, "v1.7.12"),
+        FakeCompletedProcess(3, "", "fatal error"),
+    ]
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: responses.pop(0))
+    analyzer = ActionlintAnalyzer()
+    with pytest.raises(RuntimeError, match="actionlint check failed"):
+        analyzer.check_workflow("on: push\n")
+
+
+def test_check_workflow_bad_returncode_empty_stderr(monkeypatch: Any) -> None:
+    responses = [
+        FakeCompletedProcess(0, "v1.7.12"),
+        FakeCompletedProcess(3, "", ""),
+    ]
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: responses.pop(0))
+    analyzer = ActionlintAnalyzer()
+    with pytest.raises(RuntimeError, match="actionlint check failed"):
+        analyzer.check_workflow("on: push\n")
+
+
+def test_check_workflow_json_decode_error(monkeypatch: Any) -> None:
+    responses = [
+        FakeCompletedProcess(0, "v1.7.12"),
+        FakeCompletedProcess(1, "NOT_VALID_JSON"),
+    ]
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: responses.pop(0))
+    analyzer = ActionlintAnalyzer()
+    with pytest.raises(RuntimeError, match="Failed to parse actionlint output"):
+        analyzer.check_workflow("on: push\n")
+
+
+def test_check_workflow_timeout(monkeypatch: Any) -> None:
+    call_count = [0]
+
+    def fake_run(*args: Any, **kwargs: Any) -> FakeCompletedProcess:
+        call_count[0] += 1
+        if call_count[0] == 1:
+            return FakeCompletedProcess(0, "v1.7.12")
+        raise subprocess.TimeoutExpired("actionlint", 30)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    analyzer = ActionlintAnalyzer()
+    with pytest.raises(RuntimeError, match="actionlint check timed out"):
+        analyzer.check_workflow("on: push\n")
+
+
+def test_check_workflow_file_not_found(monkeypatch: Any) -> None:
+    call_count = [0]
+
+    def fake_run(*args: Any, **kwargs: Any) -> FakeCompletedProcess:
+        call_count[0] += 1
+        if call_count[0] == 1:
+            return FakeCompletedProcess(0, "v1.7.12")
+        raise FileNotFoundError("actionlint vanished")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    analyzer = ActionlintAnalyzer()
+    with pytest.raises(RuntimeError, match="Failed to run actionlint"):
+        analyzer.check_workflow("on: push\n")
+
+
+def test_check_workflow_permission_error(monkeypatch: Any) -> None:
+    call_count = [0]
+
+    def fake_run(*args: Any, **kwargs: Any) -> FakeCompletedProcess:
+        call_count[0] += 1
+        if call_count[0] == 1:
+            return FakeCompletedProcess(0, "v1.7.12")
+        raise PermissionError("permission denied")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    analyzer = ActionlintAnalyzer()
+    with pytest.raises(RuntimeError, match="Failed to run actionlint"):
+        analyzer.check_workflow("on: push\n")

--- a/tests/test_e2e_mcp.py
+++ b/tests/test_e2e_mcp.py
@@ -1,6 +1,7 @@
 """FastMCP in-process E2E tests using Client(mcp) transport."""
 
 import json
+from pathlib import Path
 
 import pytest
 import pytest_asyncio
@@ -9,6 +10,8 @@ from fastmcp.exceptions import ToolError
 
 from mcp_server_analyzer import server
 from mcp_server_analyzer.server import mcp
+
+_SEMGREP_RULES_FIXTURE = str(Path(__file__).parent / "fixtures" / "semgrep_rules.yml")
 
 
 @pytest_asyncio.fixture
@@ -29,6 +32,9 @@ async def test_list_tools(client):
         "vulture-scan",
         "biome-check",
         "biome-format",
+        "semgrep-check",
+        "actionlint-check",
+        "gitleaks-scan",
         "analyze-code",
     }
     assert expected == tool_names
@@ -177,6 +183,9 @@ async def test_read_versions_resource(client):
     assert "ruff" in parsed
     assert "vulture" in parsed
     assert "fastmcp" in parsed
+    # semgrep/actionlint/gitleaks are external tools, not pyproject.toml
+    # dependencies, so they're excluded here (same as biome)
+    assert "semgrep" not in parsed
 
 
 @pytest.mark.asyncio
@@ -206,3 +215,49 @@ async def test_biome_format_tool(client):
         "biome-format", {"code": "const x=1\n", "filename": "code.ts"}
     )
     assert not result.is_error
+
+
+@pytest.mark.asyncio
+async def test_semgrep_check_tool(client):
+    """Uses a local rule fixture instead of config="auto" to avoid a network
+    dependency on the Semgrep registry in this e2e test."""
+    if not server.semgrep_available:
+        pytest.skip("semgrep not available")
+    result = await client.call_tool(
+        "semgrep-check",
+        {
+            "code": "eval('1+1')\n",
+            "config": _SEMGREP_RULES_FIXTURE,
+            "filename": "code.py",
+        },
+    )
+    assert not result.is_error
+    parsed = result.structured_content
+    assert parsed["total_issues"] == 1
+    assert parsed["issues"][0]["check_id"].endswith("no-eval")
+
+
+@pytest.mark.asyncio
+async def test_actionlint_check_tool(client):
+    if not server.actionlint_available:
+        pytest.skip("actionlint not available")
+    code = "on: push\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hi\n"
+    result = await client.call_tool(
+        "actionlint-check", {"code": code, "filename": "workflow.yml"}
+    )
+    assert not result.is_error
+    parsed = result.structured_content
+    assert "total_issues" in parsed
+
+
+@pytest.mark.asyncio
+async def test_gitleaks_scan_tool(client):
+    if not server.gitleaks_available:
+        pytest.skip("gitleaks not available")
+    result = await client.call_tool(
+        "gitleaks-scan", {"code": "hello world\n", "filename": "code.txt"}
+    )
+    assert not result.is_error
+    parsed = result.structured_content
+    assert "total_findings" in parsed
+    assert "findings" in parsed

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -76,6 +76,27 @@ class TestServerToolsUnavailable:
         with pytest.raises(ToolError, match="not available"):
             fn("const x = 1;")
 
+    def test_semgrep_check_unavailable(self, monkeypatch):
+        """Test semgrep_check raises ToolError when unavailable."""
+        monkeypatch.setattr(server, "semgrep_available", False)
+        fn = _get_fn(server.semgrep_check)
+        with pytest.raises(ToolError, match="not available"):
+            fn("x = 1")
+
+    def test_actionlint_check_unavailable(self, monkeypatch):
+        """Test actionlint_check raises ToolError when unavailable."""
+        monkeypatch.setattr(server, "actionlint_available", False)
+        fn = _get_fn(server.actionlint_check)
+        with pytest.raises(ToolError, match="not available"):
+            fn("on: push")
+
+    def test_gitleaks_scan_unavailable(self, monkeypatch):
+        """Test gitleaks_scan raises ToolError when unavailable."""
+        monkeypatch.setattr(server, "gitleaks_available", False)
+        fn = _get_fn(server.gitleaks_scan)
+        with pytest.raises(ToolError, match="not available"):
+            fn("hello world")
+
 
 class TestServerToolsExceptions:
     """Tests for tool functions handling analyzer exceptions."""
@@ -156,6 +177,39 @@ class TestServerToolsExceptions:
         fn = _get_fn(server.biome_format)
         with pytest.raises(ToolError, match="Biome format failed"):
             fn("const x = 1;")
+
+    def test_semgrep_check_exception(self, monkeypatch):
+        """Test semgrep_check raises ToolError on analyzer exception."""
+        mock_analyzer = Mock()
+        mock_analyzer.check_code.side_effect = RuntimeError("Check failed")
+        monkeypatch.setattr(server, "semgrep_analyzer", mock_analyzer)
+        monkeypatch.setattr(server, "semgrep_available", True)
+
+        fn = _get_fn(server.semgrep_check)
+        with pytest.raises(ToolError, match="Semgrep check failed"):
+            fn("x = 1")
+
+    def test_actionlint_check_exception(self, monkeypatch):
+        """Test actionlint_check raises ToolError on analyzer exception."""
+        mock_analyzer = Mock()
+        mock_analyzer.check_workflow.side_effect = RuntimeError("Check failed")
+        monkeypatch.setattr(server, "actionlint_analyzer", mock_analyzer)
+        monkeypatch.setattr(server, "actionlint_available", True)
+
+        fn = _get_fn(server.actionlint_check)
+        with pytest.raises(ToolError, match="actionlint check failed"):
+            fn("on: push")
+
+    def test_gitleaks_scan_exception(self, monkeypatch):
+        """Test gitleaks_scan raises ToolError on analyzer exception."""
+        mock_analyzer = Mock()
+        mock_analyzer.scan_code.side_effect = RuntimeError("Scan failed")
+        monkeypatch.setattr(server, "gitleaks_analyzer", mock_analyzer)
+        monkeypatch.setattr(server, "gitleaks_available", True)
+
+        fn = _get_fn(server.gitleaks_scan)
+        with pytest.raises(ToolError, match="gitleaks scan failed"):
+            fn("hello world")
 
 
 class TestAnalyzeCodeErrorPaths:
@@ -429,6 +483,42 @@ class TestToolErrorOnEmptyInput:
         fn = _get_fn(server.biome_format)
         with pytest.raises(ToolError, match="must not be empty"):
             fn("   ")
+
+    def test_semgrep_check_empty_input(self):
+        """Test semgrep_check raises ToolError on empty input."""
+        fn = _get_fn(server.semgrep_check)
+        with pytest.raises(ToolError, match="must not be empty"):
+            fn("")
+
+    def test_semgrep_check_whitespace_input(self):
+        """Test semgrep_check raises ToolError on whitespace-only input."""
+        fn = _get_fn(server.semgrep_check)
+        with pytest.raises(ToolError, match="must not be empty"):
+            fn("   \n\t  ")
+
+    def test_actionlint_check_empty_input(self):
+        """Test actionlint_check raises ToolError on empty input."""
+        fn = _get_fn(server.actionlint_check)
+        with pytest.raises(ToolError, match="must not be empty"):
+            fn("")
+
+    def test_actionlint_check_whitespace_input(self):
+        """Test actionlint_check raises ToolError on whitespace-only input."""
+        fn = _get_fn(server.actionlint_check)
+        with pytest.raises(ToolError, match="must not be empty"):
+            fn("   \n\t  ")
+
+    def test_gitleaks_scan_empty_input(self):
+        """Test gitleaks_scan raises ToolError on empty input."""
+        fn = _get_fn(server.gitleaks_scan)
+        with pytest.raises(ToolError, match="must not be empty"):
+            fn("")
+
+    def test_gitleaks_scan_whitespace_input(self):
+        """Test gitleaks_scan raises ToolError on whitespace-only input."""
+        fn = _get_fn(server.gitleaks_scan)
+        with pytest.raises(ToolError, match="must not be empty"):
+            fn("   \n\t  ")
 
     def test_analyze_code_empty_input(self):
         """Test analyze_code raises ToolError on empty input."""
@@ -990,3 +1080,31 @@ class TestBiomeNullAnalyzerGuards:
         fn = _get_fn(server.biome_format)
         with pytest.raises(ToolError, match="not available"):
             fn("const x = 1;\n")
+
+
+class TestSecurityAnalyzerNullAnalyzerGuards:
+    """Tests for null analyzer type guards in the semgrep/actionlint/gitleaks tools."""
+
+    def test_semgrep_check_null_analyzer(self, monkeypatch):
+        """Test semgrep_check raises ToolError when analyzer is None."""
+        monkeypatch.setattr(server, "semgrep_available", True)
+        monkeypatch.setattr(server, "semgrep_analyzer", None)
+        fn = _get_fn(server.semgrep_check)
+        with pytest.raises(ToolError, match="not available"):
+            fn("x = 1\n")
+
+    def test_actionlint_check_null_analyzer(self, monkeypatch):
+        """Test actionlint_check raises ToolError when analyzer is None."""
+        monkeypatch.setattr(server, "actionlint_available", True)
+        monkeypatch.setattr(server, "actionlint_analyzer", None)
+        fn = _get_fn(server.actionlint_check)
+        with pytest.raises(ToolError, match="not available"):
+            fn("on: push\n")
+
+    def test_gitleaks_scan_null_analyzer(self, monkeypatch):
+        """Test gitleaks_scan raises ToolError when analyzer is None."""
+        monkeypatch.setattr(server, "gitleaks_available", True)
+        monkeypatch.setattr(server, "gitleaks_analyzer", None)
+        fn = _get_fn(server.gitleaks_scan)
+        with pytest.raises(ToolError, match="not available"):
+            fn("hello world\n")

--- a/tests/test_gitleaks_analyzer.py
+++ b/tests/test_gitleaks_analyzer.py
@@ -1,0 +1,225 @@
+"""Unit tests for GitleaksAnalyzer using monkeypatching (no real gitleaks needed)."""
+
+import json
+import subprocess
+from typing import Any
+
+import pytest
+
+from mcp_server_analyzer.analyzers.gitleaks import GitleaksAnalyzer
+
+
+class FakeCompletedProcess:
+    def __init__(self, returncode: int, stdout: str = "", stderr: str = "") -> None:
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+# ── _check_gitleaks_installation ────────────────────────────────────────────
+
+
+def test_check_installation_ok(monkeypatch: Any) -> None:
+    monkeypatch.setattr(
+        subprocess, "run", lambda *a, **k: FakeCompletedProcess(0, "8.30.1")
+    )
+    GitleaksAnalyzer()
+
+
+def test_check_installation_raises_on_called_process_error(monkeypatch: Any) -> None:
+    def fake_run(*args: Any, **kwargs: Any) -> FakeCompletedProcess:
+        raise subprocess.CalledProcessError(1, "gitleaks")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    with pytest.raises(RuntimeError, match="gitleaks is not available"):
+        GitleaksAnalyzer()
+
+
+def test_check_installation_raises_on_file_not_found(monkeypatch: Any) -> None:
+    def fake_run(*args: Any, **kwargs: Any) -> FakeCompletedProcess:
+        raise FileNotFoundError("not found")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    with pytest.raises(RuntimeError, match="gitleaks is not available"):
+        GitleaksAnalyzer()
+
+
+def test_check_installation_raises_on_timeout(monkeypatch: Any) -> None:
+    def fake_run(*args: Any, **kwargs: Any) -> FakeCompletedProcess:
+        raise subprocess.TimeoutExpired("gitleaks", 10)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    with pytest.raises(RuntimeError, match="gitleaks is not available"):
+        GitleaksAnalyzer()
+
+
+# ── scan_code ────────────────────────────────────────────────────────────────
+
+
+def test_scan_code_no_findings(monkeypatch: Any) -> None:
+    responses = [
+        FakeCompletedProcess(0, "8.30.1"),
+        FakeCompletedProcess(0, "[]"),
+    ]
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: responses.pop(0))
+    analyzer = GitleaksAnalyzer()
+    result = analyzer.scan_code("hello world\n")
+    assert result.total_findings == 0
+    assert result.findings == []
+
+
+def test_scan_code_redacts_secret_values(monkeypatch: Any) -> None:
+    """Security-critical: raw secret values must never be returned, always 'REDACTED'."""
+    finding = {
+        "RuleID": "private-key",
+        "Description": "Identified a Private Key",
+        "StartLine": 1,
+        "EndLine": 28,
+        "StartColumn": 1,
+        "EndColumn": 26,
+        "Match": "REDACTED",
+        "Secret": "REDACTED",
+        "File": "/private/var/tmp-workdir/some-temp-file.pem",
+        "Entropy": 6.01,
+    }
+    responses = [
+        FakeCompletedProcess(0, "8.30.1"),
+        FakeCompletedProcess(1, json.dumps([finding])),
+    ]
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: responses.pop(0))
+    analyzer = GitleaksAnalyzer()
+    result = analyzer.scan_code("-----BEGIN PRIVATE KEY-----\n...\n", "key.pem")
+    assert result.total_findings == 1
+    found = result.findings[0]
+    assert found.rule_id == "private-key"
+    assert found.secret == "REDACTED"  # noqa: S105 -- asserting redaction, not a real secret
+    assert found.match == "REDACTED"
+    # caller-supplied filename must override the raw OS temp path gitleaks reports
+    assert found.file == "key.pem"
+    assert found.start_line == 1
+    assert found.end_line == 28
+    assert found.start_column == 1
+    assert found.end_column == 26
+
+
+def test_scan_code_missing_optional_fields(monkeypatch: Any) -> None:
+    finding = {"RuleID": "generic-api-key"}
+    responses = [
+        FakeCompletedProcess(0, "8.30.1"),
+        FakeCompletedProcess(1, json.dumps([finding])),
+    ]
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: responses.pop(0))
+    analyzer = GitleaksAnalyzer()
+    result = analyzer.scan_code("api_key = 'x'\n")
+    assert result.total_findings == 1
+    found = result.findings[0]
+    assert found.description == ""
+    assert found.secret == "REDACTED"  # noqa: S105 -- asserting redaction, not a real secret
+    assert found.match == "REDACTED"
+    assert found.start_line == 0
+
+
+def test_scan_code_empty_stdout(monkeypatch: Any) -> None:
+    responses = [
+        FakeCompletedProcess(0, "8.30.1"),
+        FakeCompletedProcess(0, ""),
+    ]
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: responses.pop(0))
+    analyzer = GitleaksAnalyzer()
+    result = analyzer.scan_code("hello world\n")
+    assert result.total_findings == 0
+
+
+def test_scan_code_bad_returncode_with_stderr(monkeypatch: Any) -> None:
+    responses = [
+        FakeCompletedProcess(0, "8.30.1"),
+        FakeCompletedProcess(2, "", "invalid config"),
+    ]
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: responses.pop(0))
+    analyzer = GitleaksAnalyzer()
+    with pytest.raises(RuntimeError, match="gitleaks scan failed"):
+        analyzer.scan_code("hello world\n")
+
+
+def test_scan_code_bad_returncode_empty_stderr(monkeypatch: Any) -> None:
+    responses = [
+        FakeCompletedProcess(0, "8.30.1"),
+        FakeCompletedProcess(2, "", ""),
+    ]
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: responses.pop(0))
+    analyzer = GitleaksAnalyzer()
+    with pytest.raises(RuntimeError, match="gitleaks scan failed"):
+        analyzer.scan_code("hello world\n")
+
+
+def test_scan_code_json_decode_error(monkeypatch: Any) -> None:
+    responses = [
+        FakeCompletedProcess(0, "8.30.1"),
+        FakeCompletedProcess(1, "NOT_VALID_JSON"),
+    ]
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: responses.pop(0))
+    analyzer = GitleaksAnalyzer()
+    with pytest.raises(RuntimeError, match="Failed to parse gitleaks output"):
+        analyzer.scan_code("hello world\n")
+
+
+def test_scan_code_timeout(monkeypatch: Any) -> None:
+    call_count = [0]
+
+    def fake_run(*args: Any, **kwargs: Any) -> FakeCompletedProcess:
+        call_count[0] += 1
+        if call_count[0] == 1:
+            return FakeCompletedProcess(0, "8.30.1")
+        raise subprocess.TimeoutExpired("gitleaks", 30)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    analyzer = GitleaksAnalyzer()
+    with pytest.raises(RuntimeError, match="gitleaks scan timed out"):
+        analyzer.scan_code("hello world\n")
+
+
+def test_scan_code_file_not_found(monkeypatch: Any) -> None:
+    call_count = [0]
+
+    def fake_run(*args: Any, **kwargs: Any) -> FakeCompletedProcess:
+        call_count[0] += 1
+        if call_count[0] == 1:
+            return FakeCompletedProcess(0, "8.30.1")
+        raise FileNotFoundError("gitleaks vanished")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    analyzer = GitleaksAnalyzer()
+    with pytest.raises(RuntimeError, match="Failed to run gitleaks"):
+        analyzer.scan_code("hello world\n")
+
+
+def test_scan_code_permission_error(monkeypatch: Any) -> None:
+    call_count = [0]
+
+    def fake_run(*args: Any, **kwargs: Any) -> FakeCompletedProcess:
+        call_count[0] += 1
+        if call_count[0] == 1:
+            return FakeCompletedProcess(0, "8.30.1")
+        raise PermissionError("permission denied")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    analyzer = GitleaksAnalyzer()
+    with pytest.raises(RuntimeError, match="Failed to run gitleaks"):
+        analyzer.scan_code("hello world\n")
+
+
+def test_scan_code_always_passes_redact_flag(monkeypatch: Any) -> None:
+    """Security-critical: --redact must always be present in the gitleaks command."""
+    captured_cmds = []
+
+    def fake_run(cmd: list, **kwargs: Any) -> FakeCompletedProcess:
+        captured_cmds.append(cmd)
+        if "version" in cmd:
+            return FakeCompletedProcess(0, "8.30.1")
+        return FakeCompletedProcess(0, "[]")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    analyzer = GitleaksAnalyzer()
+    analyzer.scan_code("hello world\n")
+    scan_cmd = captured_cmds[-1]
+    assert "--redact" in scan_cmd

--- a/tests/test_semgrep_analyzer.py
+++ b/tests/test_semgrep_analyzer.py
@@ -1,0 +1,295 @@
+"""Unit tests for SemgrepAnalyzer using monkeypatching (no real semgrep needed)."""
+
+import json
+import subprocess
+from typing import Any
+
+import pytest
+
+from mcp_server_analyzer.analyzers.semgrep import SemgrepAnalyzer
+
+
+class FakeCompletedProcess:
+    def __init__(self, returncode: int, stdout: str = "", stderr: str = "") -> None:
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+# ── _find_semgrep_cmd ────────────────────────────────────────────────────────
+
+
+def test_find_semgrep_cmd_uses_local_semgrep(monkeypatch: Any) -> None:
+    monkeypatch.setattr(
+        subprocess, "run", lambda *a, **k: FakeCompletedProcess(0, "1.90.0")
+    )
+    analyzer = SemgrepAnalyzer()
+    assert analyzer._semgrep_cmd == ["semgrep"]
+
+
+def test_find_semgrep_cmd_falls_back_to_uvx(monkeypatch: Any) -> None:
+    call_count = [0]
+
+    def fake_run(*args: Any, **kwargs: Any) -> FakeCompletedProcess:
+        call_count[0] += 1
+        if call_count[0] == 1:
+            raise FileNotFoundError("semgrep not in PATH")
+        return FakeCompletedProcess(0, "1.90.0")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    analyzer = SemgrepAnalyzer()
+    assert analyzer._semgrep_cmd == ["uvx", "semgrep"]
+
+
+def test_find_semgrep_cmd_raises_when_neither_available(monkeypatch: Any) -> None:
+    def fake_run(*args: Any, **kwargs: Any) -> FakeCompletedProcess:
+        raise FileNotFoundError("not found")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    with pytest.raises(RuntimeError, match="Semgrep is not available"):
+        SemgrepAnalyzer()
+
+
+def test_find_semgrep_cmd_raises_on_called_process_error(monkeypatch: Any) -> None:
+    def fake_run(*args: Any, **kwargs: Any) -> FakeCompletedProcess:
+        raise subprocess.CalledProcessError(1, "semgrep")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    with pytest.raises(RuntimeError, match="Semgrep is not available"):
+        SemgrepAnalyzer()
+
+
+def test_find_semgrep_cmd_raises_on_timeout(monkeypatch: Any) -> None:
+    def fake_run(*args: Any, **kwargs: Any) -> FakeCompletedProcess:
+        raise subprocess.TimeoutExpired("semgrep", 10)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    with pytest.raises(RuntimeError, match="Semgrep is not available"):
+        SemgrepAnalyzer()
+
+
+# ── check_code ───────────────────────────────────────────────────────────────
+
+
+def test_check_code_no_issues(monkeypatch: Any) -> None:
+    responses = [
+        FakeCompletedProcess(0, "1.90.0"),
+        FakeCompletedProcess(0, json.dumps({"results": [], "errors": []})),
+    ]
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: responses.pop(0))
+    analyzer = SemgrepAnalyzer()
+    result = analyzer.check_code("x = 1\n")
+    assert result.total_issues == 0
+    assert result.error_count == 0
+    assert result.warning_count == 0
+    assert result.issues == []
+
+
+def test_check_code_with_findings(monkeypatch: Any) -> None:
+    finding = {
+        "check_id": "python.lang.security.audit.subprocess-shell-true",
+        "path": "PLACEHOLDER",
+        "start": {"line": 5, "col": 38, "offset": 91},
+        "end": {"line": 5, "col": 42, "offset": 95},
+        "extra": {
+            "severity": "ERROR",
+            "message": "Found subprocess with shell=True",
+            "metadata": {
+                "cwe": ["CWE-78: OS Command Injection"],
+                "owasp": ["A03:2021 - Injection"],
+            },
+        },
+    }
+
+    def fake_run(cmd: list, **kwargs: Any) -> FakeCompletedProcess:
+        if "--version" in cmd:
+            return FakeCompletedProcess(0, "1.90.0")
+        temp_path = cmd[-1]
+        finding["path"] = temp_path
+        return FakeCompletedProcess(0, json.dumps({"results": [finding], "errors": []}))
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    analyzer = SemgrepAnalyzer()
+    result = analyzer.check_code(
+        "import subprocess\nsubprocess.run('ls', shell=True)\n"
+    )
+    assert result.total_issues == 1
+    assert result.error_count == 1
+    assert result.warning_count == 0
+    issue = result.issues[0]
+    assert issue.check_id == "python.lang.security.audit.subprocess-shell-true"
+    assert issue.line == 5
+    assert issue.column == 38
+    assert issue.end_line == 5
+    assert issue.end_column == 42
+    assert issue.severity == "ERROR"
+    assert issue.cwe == ["CWE-78: OS Command Injection"]
+    assert issue.owasp == ["A03:2021 - Injection"]
+
+
+def test_check_code_findings_missing_metadata(monkeypatch: Any) -> None:
+    def fake_run(cmd: list, **kwargs: Any) -> FakeCompletedProcess:
+        if "--version" in cmd:
+            return FakeCompletedProcess(0, "1.90.0")
+        temp_path = cmd[-1]
+        finding = {
+            "check_id": "rule-x",
+            "path": temp_path,
+            "start": {},
+            "end": {},
+            "extra": {},
+        }
+        return FakeCompletedProcess(0, json.dumps({"results": [finding], "errors": []}))
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    analyzer = SemgrepAnalyzer()
+    result = analyzer.check_code("x = 1\n")
+    assert result.total_issues == 1
+    issue = result.issues[0]
+    assert issue.line == 0
+    assert issue.column == 0
+    assert issue.severity == "INFO"
+    assert issue.message == ""
+    assert issue.cwe == []
+    assert issue.owasp == []
+
+
+def test_check_code_filters_unrelated_paths(monkeypatch: Any) -> None:
+    def fake_run(cmd: list, **kwargs: Any) -> FakeCompletedProcess:
+        if "--version" in cmd:
+            return FakeCompletedProcess(0, "1.90.0")
+        finding = {
+            "check_id": "rule-x",
+            "path": "/some/unrelated/file.py",
+            "start": {"line": 1, "col": 1},
+            "end": {"line": 1, "col": 2},
+            "extra": {"severity": "WARNING", "message": "noise"},
+        }
+        return FakeCompletedProcess(0, json.dumps({"results": [finding], "errors": []}))
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    analyzer = SemgrepAnalyzer()
+    result = analyzer.check_code("x = 1\n")
+    assert result.total_issues == 0
+
+
+def test_check_code_empty_stdout(monkeypatch: Any) -> None:
+    responses = [
+        FakeCompletedProcess(0, "1.90.0"),
+        FakeCompletedProcess(0, ""),
+    ]
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: responses.pop(0))
+    analyzer = SemgrepAnalyzer()
+    result = analyzer.check_code("x = 1\n")
+    assert result.total_issues == 0
+
+
+def test_check_code_bad_returncode_with_stderr(monkeypatch: Any) -> None:
+    responses = [
+        FakeCompletedProcess(0, "1.90.0"),
+        FakeCompletedProcess(7, "", "invalid config"),
+    ]
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: responses.pop(0))
+    analyzer = SemgrepAnalyzer()
+    with pytest.raises(RuntimeError, match="Semgrep check failed"):
+        analyzer.check_code("x = 1\n")
+
+
+def test_check_code_bad_returncode_empty_stderr(monkeypatch: Any) -> None:
+    responses = [
+        FakeCompletedProcess(0, "1.90.0"),
+        FakeCompletedProcess(7, "", ""),
+    ]
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: responses.pop(0))
+    analyzer = SemgrepAnalyzer()
+    with pytest.raises(RuntimeError, match="Semgrep check failed"):
+        analyzer.check_code("x = 1\n")
+
+
+def test_check_code_json_decode_error(monkeypatch: Any) -> None:
+    responses = [
+        FakeCompletedProcess(0, "1.90.0"),
+        FakeCompletedProcess(0, "NOT_VALID_JSON"),
+    ]
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: responses.pop(0))
+    analyzer = SemgrepAnalyzer()
+    with pytest.raises(RuntimeError, match="Failed to parse Semgrep output"):
+        analyzer.check_code("x = 1\n")
+
+
+def test_check_code_timeout(monkeypatch: Any) -> None:
+    call_count = [0]
+
+    def fake_run(*args: Any, **kwargs: Any) -> FakeCompletedProcess:
+        call_count[0] += 1
+        if call_count[0] == 1:
+            return FakeCompletedProcess(0, "1.90.0")
+        raise subprocess.TimeoutExpired("semgrep", 60)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    analyzer = SemgrepAnalyzer()
+    with pytest.raises(RuntimeError, match="Semgrep check timed out"):
+        analyzer.check_code("x = 1\n")
+
+
+def test_check_code_file_not_found(monkeypatch: Any) -> None:
+    call_count = [0]
+
+    def fake_run(*args: Any, **kwargs: Any) -> FakeCompletedProcess:
+        call_count[0] += 1
+        if call_count[0] == 1:
+            return FakeCompletedProcess(0, "1.90.0")
+        raise FileNotFoundError("semgrep vanished")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    analyzer = SemgrepAnalyzer()
+    with pytest.raises(RuntimeError, match="Failed to run Semgrep"):
+        analyzer.check_code("x = 1\n")
+
+
+def test_check_code_permission_error(monkeypatch: Any) -> None:
+    call_count = [0]
+
+    def fake_run(*args: Any, **kwargs: Any) -> FakeCompletedProcess:
+        call_count[0] += 1
+        if call_count[0] == 1:
+            return FakeCompletedProcess(0, "1.90.0")
+        raise PermissionError("permission denied")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    analyzer = SemgrepAnalyzer()
+    with pytest.raises(RuntimeError, match="Failed to run Semgrep"):
+        analyzer.check_code("x = 1\n")
+
+
+def test_check_code_default_config_omits_metrics_off(monkeypatch: Any) -> None:
+    """--metrics=off cannot be combined with --config auto; must be omitted for auto."""
+    captured_cmds = []
+
+    def fake_run(cmd: list, **kwargs: Any) -> FakeCompletedProcess:
+        captured_cmds.append(cmd)
+        if "--version" in cmd:
+            return FakeCompletedProcess(0, "1.90.0")
+        return FakeCompletedProcess(0, json.dumps({"results": [], "errors": []}))
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    analyzer = SemgrepAnalyzer()
+    analyzer.check_code("x = 1\n", config="auto")
+    scan_cmd = captured_cmds[-1]
+    assert "--metrics=off" not in scan_cmd
+
+
+def test_check_code_explicit_config_adds_metrics_off(monkeypatch: Any) -> None:
+    captured_cmds = []
+
+    def fake_run(cmd: list, **kwargs: Any) -> FakeCompletedProcess:
+        captured_cmds.append(cmd)
+        if "--version" in cmd:
+            return FakeCompletedProcess(0, "1.90.0")
+        return FakeCompletedProcess(0, json.dumps({"results": [], "errors": []}))
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    analyzer = SemgrepAnalyzer()
+    analyzer.check_code("x = 1\n", config="p/security-audit")
+    scan_cmd = captured_cmds[-1]
+    assert "--metrics=off" in scan_cmd

--- a/tests/test_server_tools.py
+++ b/tests/test_server_tools.py
@@ -1,10 +1,13 @@
 from mcp_server_analyzer import server
 from mcp_server_analyzer.models import (
+    ActionlintCheckResult,
     AnalysisResult,
     BiomeCheckResult,
     BiomeFormatResult,
+    GitleaksScanResult,
     RuffCheckResult,
     RuffCICheckResult,
+    SemgrepScanResult,
 )
 
 
@@ -62,6 +65,53 @@ def test_server_biome_wrappers(monkeypatch):
     res_fmt = _get_fn(server.biome_format)("const x = 1;\n")
     assert isinstance(res_fmt, BiomeFormatResult)
     assert res_fmt.changed is False
+
+
+class FakeSemgrepAnalyzer:
+    def check_code(self, code, config="auto", filename="code.py"):
+        return SemgrepScanResult(
+            issues=[], total_issues=0, error_count=0, warning_count=0
+        )
+
+
+def test_server_semgrep_wrappers(monkeypatch):
+    fake = FakeSemgrepAnalyzer()
+    monkeypatch.setattr(server, "semgrep_analyzer", fake)
+    monkeypatch.setattr(server, "semgrep_available", True)
+
+    res = _get_fn(server.semgrep_check)("x = 1\n")
+    assert isinstance(res, SemgrepScanResult)
+    assert res.total_issues == 0
+
+
+class FakeActionlintAnalyzer:
+    def check_workflow(self, code, filename="workflow.yml"):
+        return ActionlintCheckResult(issues=[], total_issues=0)
+
+
+def test_server_actionlint_wrappers(monkeypatch):
+    fake = FakeActionlintAnalyzer()
+    monkeypatch.setattr(server, "actionlint_analyzer", fake)
+    monkeypatch.setattr(server, "actionlint_available", True)
+
+    res = _get_fn(server.actionlint_check)("on: push\n")
+    assert isinstance(res, ActionlintCheckResult)
+    assert res.total_issues == 0
+
+
+class FakeGitleaksAnalyzer:
+    def scan_code(self, code, filename="code.txt"):
+        return GitleaksScanResult(findings=[], total_findings=0)
+
+
+def test_server_gitleaks_wrappers(monkeypatch):
+    fake = FakeGitleaksAnalyzer()
+    monkeypatch.setattr(server, "gitleaks_analyzer", fake)
+    monkeypatch.setattr(server, "gitleaks_available", True)
+
+    res = _get_fn(server.gitleaks_scan)("hello world\n")
+    assert isinstance(res, GitleaksScanResult)
+    assert res.total_findings == 0
 
 
 def test_analyze_code_with_missing_analyzers(monkeypatch):

--- a/uv.lock
+++ b/uv.lock
@@ -9,18 +9,6 @@ resolution-markers = [
 ]
 
 [[package]]
-name = "aiofile"
-version = "3.11.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "caio" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/48/41/2fea7e193e061ce54eacc3b7bc0e6a99e4fcff43c78cf0a76dd781ed8334/aiofile-3.11.1.tar.gz", hash = "sha256:1f91912c6643d2a4e49ca4ae3514f0bf3867ce948a36d99a6411b8f4755f4cf9", size = 19342, upload-time = "2026-05-16T08:18:33.538Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/67/cd/0d76dfc5de72bde52f55f53e925c7d152d9c7906634ec1e0cbc7e8d4ad93/aiofile-3.11.1-py3-none-any.whl", hash = "sha256:ce77d14ac07f77bc2b757834a5c129321f3f705c474593deed5ab209079a52c9", size = 20446, upload-time = "2026-05-16T08:18:32.051Z" },
-]
-
-[[package]]
 name = "annotated-doc"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -97,29 +85,28 @@ wheels = [
 ]
 
 [[package]]
+name = "burner-redis"
+version = "0.1.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/89/54706febafc135095b2a9d797cfbd4eed2ab1ad7819808b99b587020471b/burner_redis-0.1.7.tar.gz", hash = "sha256:7474ff092669fd11ef765411572cdafcc3d89b8054aef4ca0617be6d6be4c680", size = 638644, upload-time = "2026-05-08T15:01:42.961Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6c/5d/198bd1d22e504b3034353430703afbdb3efe6e25cb90bf52d896e1d266a7/burner_redis-0.1.7-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:f80c866996e0455d584eb3c0f3b067e411c632fb0519eab454e0968edf01e62c", size = 1288888, upload-time = "2026-05-08T15:01:26.103Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/4e/ce5c91b884ac37fcd380756402536f8810964014097950900517ce8bd30c/burner_redis-0.1.7-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:a3d9569a376b690fb5876d454e4904443332dc3ad5c0057e149fc2ad220bf599", size = 1234282, upload-time = "2026-05-08T15:01:28.286Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/c0/31c25cc88143eac2dddcc394151a0db627923d44c94376a83768552c9f13/burner_redis-0.1.7-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:20eba1917e3bca9eea5957d5700ff8defcb5a209e57a7841d005549aa0151f44", size = 1337341, upload-time = "2026-05-08T15:01:30.397Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/32/95cfa1833316ca2b6b2e58150a4900bc1ad256043cdd36198f1887618ccc/burner_redis-0.1.7-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:39111467059b8a28f15ea061d2414ec25c3e57c65759983f90f4d358e7d6a72d", size = 1366800, upload-time = "2026-05-08T15:01:32.891Z" },
+    { url = "https://files.pythonhosted.org/packages/34/ad/93c3916f053f89b7b5760da5bf855cd78b7885d480f9cfcc64f3732c1dc2/burner_redis-0.1.7-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9b5adfe99aeb8407f468078f3769b2a63e9168fea12f7709df5d2a3b152706e4", size = 1538160, upload-time = "2026-05-08T15:01:34.667Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/b9/19bae42cb124932d71168bc8e5bcb1da33aa62b908e5e632b3d298d7cb15/burner_redis-0.1.7-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:591a9d20685f9d6d22bf0c863b50b12dfcf328b06111b3f62c33cd3185d48ce0", size = 1591491, upload-time = "2026-05-08T15:01:36.708Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/30/207f47f406619a5b564355d2946c3171f84231a28b800709b5645b06a5ae/burner_redis-0.1.7-cp310-abi3-win_amd64.whl", hash = "sha256:f6cf4ac666766b32fd63940aad0c120847905fd3102c17e5b6b305f91a21d079", size = 1117564, upload-time = "2026-05-08T15:01:39.221Z" },
+    { url = "https://files.pythonhosted.org/packages/76/6f/e9beaf46c5e9fd10dfcdb889ebf7d3aa85142c650c0ab17ab284194f58e1/burner_redis-0.1.7-cp310-abi3-win_arm64.whl", hash = "sha256:458f88feeddfb40a586cc3fcbd8e9384bbdfd2a4512a695af4900e06052570d4", size = 1040407, upload-time = "2026-05-08T15:01:41.235Z" },
+]
+
+[[package]]
 name = "cachetools"
 version = "7.1.4"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f4/8b/0d3945a13955303b81272f759a0331e54c5c793da455e6f5706b89d2639c/cachetools-7.1.4.tar.gz", hash = "sha256:437f55a4e0c1b01a4f3077cc470e6991d47430970e36fbcb77e2be0df4fc1cd6", size = 40085, upload-time = "2026-05-21T22:40:43.376Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8c/7b/1fc1c09cc0756cf25861a3be10565915953876da48bb228fb9a672b20a42/cachetools-7.1.4-py3-none-any.whl", hash = "sha256:323dc4127934744db5b54eb4924482d7edafbf9554e820d1531c2e08c0e4ef54", size = 16761, upload-time = "2026-05-21T22:40:41.845Z" },
-]
-
-[[package]]
-name = "caio"
-version = "0.9.25"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/92/88/b8527e1b00c1811db339a1df8bd1ae49d146fcea9d6a5c40e3a80aaeb38d/caio-0.9.25.tar.gz", hash = "sha256:16498e7f81d1d0f5a4c0ad3f2540e65fe25691376e0a5bd367f558067113ed10", size = 26781, upload-time = "2025-12-26T15:21:36.501Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/31/57/5e6ff127e6f62c9f15d989560435c642144aa4210882f9494204bc892305/caio-0.9.25-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d6c2a3411af97762a2b03840c3cec2f7f728921ff8adda53d7ea2315a8563451", size = 36979, upload-time = "2025-12-26T15:21:35.484Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/9f/f21af50e72117eb528c422d4276cbac11fb941b1b812b182e0a9c70d19c5/caio-0.9.25-cp313-cp313-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0998210a4d5cd5cb565b32ccfe4e53d67303f868a76f212e002a8554692870e6", size = 81900, upload-time = "2025-12-26T15:22:21.919Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/12/c39ae2a4037cb10ad5eb3578eb4d5f8c1a2575c62bba675f3406b7ef0824/caio-0.9.25-cp313-cp313-manylinux_2_34_aarch64.whl", hash = "sha256:1a177d4777141b96f175fe2c37a3d96dec7911ed9ad5f02bac38aaa1c936611f", size = 81523, upload-time = "2026-03-04T22:08:25.187Z" },
-    { url = "https://files.pythonhosted.org/packages/22/59/f8f2e950eb4f1a5a3883e198dca514b9d475415cb6cd7b78b9213a0dd45a/caio-0.9.25-cp313-cp313-manylinux_2_34_x86_64.whl", hash = "sha256:9ed3cfb28c0e99fec5e208c934e5c157d0866aa9c32aa4dc5e9b6034af6286b7", size = 80243, upload-time = "2026-03-04T22:08:26.449Z" },
-    { url = "https://files.pythonhosted.org/packages/69/ca/a08fdc7efdcc24e6a6131a93c85be1f204d41c58f474c42b0670af8c016b/caio-0.9.25-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:fab6078b9348e883c80a5e14b382e6ad6aabbc4429ca034e76e730cf464269db", size = 36978, upload-time = "2025-12-26T15:21:41.055Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/6c/d4d24f65e690213c097174d26eda6831f45f4734d9d036d81790a27e7b78/caio-0.9.25-cp314-cp314-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:44a6b58e52d488c75cfaa5ecaa404b2b41cc965e6c417e03251e868ecd5b6d77", size = 81832, upload-time = "2025-12-26T15:22:22.757Z" },
-    { url = "https://files.pythonhosted.org/packages/87/a4/e534cf7d2d0e8d880e25dd61e8d921ffcfe15bd696734589826f5a2df727/caio-0.9.25-cp314-cp314-manylinux_2_34_aarch64.whl", hash = "sha256:628a630eb7fb22381dd8e3c8ab7f59e854b9c806639811fc3f4310c6bd711d79", size = 81565, upload-time = "2026-03-04T22:08:27.483Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/ed/bf81aeac1d290017e5e5ac3e880fd56ee15e50a6d0353986799d1bc5cfd5/caio-0.9.25-cp314-cp314-manylinux_2_34_x86_64.whl", hash = "sha256:0ba16aa605ccb174665357fc729cf500679c2d94d5f1458a6f0d5ca48f2060a7", size = 80071, upload-time = "2026-03-04T22:08:28.751Z" },
-    { url = "https://files.pythonhosted.org/packages/86/93/1f76c8d1bafe3b0614e06b2195784a3765bbf7b0a067661af9e2dd47fc33/caio-0.9.25-py3-none-any.whl", hash = "sha256:06c0bb02d6b929119b1cfbe1ca403c768b2013a369e2db46bfa2a5761cf82e40", size = 19087, upload-time = "2025-12-26T15:22:00.221Z" },
 ]
 
 [[package]]
@@ -198,6 +185,15 @@ wheels = [
 ]
 
 [[package]]
+name = "cloudpickle"
+version = "3.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/fb/576f067976d320f5f0114a8d9fa1215425441bb35627b1993e5afd8111e5/cloudpickle-3.1.2.tar.gz", hash = "sha256:7fda9eb655c9c230dab534f1983763de5835249750e85fbcef43aaa30a9a2414", size = 22330, upload-time = "2025-11-03T09:25:26.604Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl", hash = "sha256:9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a", size = 22228, upload-time = "2025-11-03T09:25:25.534Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -258,6 +254,14 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/5f/d5e5c56b0712e96ce8f69fe7dbf229ff938b437bc50862743c8a0d2cea84/coverage-7.14.3-cp314-cp314t-win_amd64.whl", hash = "sha256:39e1dbbb6ff2c338e0196a482558a792a1de3aa64261196f5cdb3da016ad9cda", size = 224082, upload-time = "2026-06-22T23:10:19.23Z" },
     { url = "https://files.pythonhosted.org/packages/62/35/947cbd5be1d3bcbbdc43d6791de8a56c6501903311d42915ae06a82815f0/coverage-7.14.3-cp314-cp314t-win_arm64.whl", hash = "sha256:68520c90babfa2d560eca6d497921ed3a4f469623bd709733124491b2aa8ef3f", size = 223400, upload-time = "2026-06-22T23:10:21.24Z" },
     { url = "https://files.pythonhosted.org/packages/eb/e3/a0aa32bfa3a081951f60a23bc0e7b512891ef0eecda1153cf1d8ba36c6b1/coverage-7.14.3-py3-none-any.whl", hash = "sha256:fb7e18afb6e903c1a92401a2f0501ac277dca527bb9ca6fe1f691a8a0026a0e8", size = 212469, upload-time = "2026-06-22T23:10:23.405Z" },
+]
+
+[[package]]
+name = "cronsim"
+version = "2.7"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/1a/02f105147f7f2e06ed4f734ff5a6439590bb275a53dd91fc73df6312298a/cronsim-2.7-py3-none-any.whl", hash = "sha256:1e1431fa08c51dc7f72e67e571c7c7a09af26420169b607badd4ca9677ffad1e", size = 14213, upload-time = "2025-10-21T16:38:20.431Z" },
 ]
 
 [[package]]
@@ -335,6 +339,15 @@ wheels = [
 ]
 
 [[package]]
+name = "diskcache"
+version = "5.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/21/1c1ffc1a039ddcc459db43cc108658f32c57d271d7289a2794e401d0fdb6/diskcache-5.6.3.tar.gz", hash = "sha256:2c3a3fa2743d8535d832ec61c2054a1641f41775aa7c556758a109941e33e4fc", size = 67916, upload-time = "2023-08-31T06:12:00.316Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/27/4570e78fc0bf5ea0ca45eb1de3818a23787af9b390c0b0a0033a1b8236f9/diskcache-5.6.3-py3-none-any.whl", hash = "sha256:5e31b2d5fbad117cc363ebaf6b689474db18a1f6438bc82358b024abd4c2ca19", size = 45550, upload-time = "2023-08-31T06:11:58.822Z" },
+]
+
+[[package]]
 name = "distlib"
 version = "0.4.3"
 source = { registry = "https://pypi.org/simple" }
@@ -388,74 +401,38 @@ wheels = [
 
 [[package]]
 name = "exceptiongroup"
-version = "1.3.1"
+version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/09/35/2495c4ac46b980e4ca1f6ad6db102322ef3ad2410b79fdde159a4b0f3b92/exceptiongroup-1.2.2.tar.gz", hash = "sha256:47c2edf7c6738fafb49fd34290706d1a1a2f4d1c6df275526b62cbb4aa5393cc", size = 28883, upload-time = "2024-07-12T22:26:00.161Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+    { url = "https://files.pythonhosted.org/packages/02/cc/b7e31358aac6ed1ef2bb790a9746ac2c69bcb3c8588b41616914eb106eaf/exceptiongroup-1.2.2-py3-none-any.whl", hash = "sha256:3111b9d131c238bec2f8f516e123e14ba243563fb135d3fe885990585aa7795b", size = 16453, upload-time = "2024-07-12T22:25:58.476Z" },
 ]
 
 [[package]]
 name = "fastmcp"
-version = "3.4.2"
+version = "2.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "fastmcp-slim", extra = ["client", "server"] },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/29/18/46beaec18c9f86a599ae3f9cdf6677dd6b50240cfd844d18233710b47f13/fastmcp-3.4.2.tar.gz", hash = "sha256:b468722946fc467c3796a6572f7a14d93d48c014cf8fea12910245220cbbe4e1", size = 28756849, upload-time = "2026-06-06T01:30:35.694Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/58/4d/8b1ba42251160e11ca34686344572121432c23a082d56ef6bbdec5888fc1/fastmcp-3.4.2-py3-none-any.whl", hash = "sha256:c87a62b029f0c5400ada85f683629345d2466c39169f0cb853e487b2f7308c08", size = 8018, upload-time = "2026-06-06T01:30:38.118Z" },
-]
-
-[[package]]
-name = "fastmcp-slim"
-version = "3.4.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "platformdirs" },
-    { name = "pydantic", extra = ["email"] },
-    { name = "pydantic-settings" },
-    { name = "python-dotenv" },
-    { name = "rich" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a3/2e/d627b28b7403ecc526991ef732921b08bde010006e6148635f053fd29f4c/fastmcp_slim-3.4.2.tar.gz", hash = "sha256:290646e0955a516235a317151034559aa48336cb843d3f006131aedad8759bb4", size = 576291, upload-time = "2026-06-06T01:30:12.553Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f7/58/22afebf18df7260b09148199cbeb90cdcc4b3a4e1b5d7460e3591c3a7add/fastmcp_slim-3.4.2-py3-none-any.whl", hash = "sha256:bdc72492212681ca502755fa8acc0457f559295da1fc3dfc0599adc1c04b82f3", size = 749195, upload-time = "2026-06-06T01:30:11.22Z" },
-]
-
-[package.optional-dependencies]
-client = [
-    { name = "authlib" },
-    { name = "exceptiongroup" },
-    { name = "httpx" },
-    { name = "mcp" },
-    { name = "opentelemetry-api" },
-    { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
-    { name = "starlette" },
-]
-server = [
     { name = "authlib" },
     { name = "cyclopts" },
     { name = "exceptiongroup" },
-    { name = "griffelib" },
     { name = "httpx" },
-    { name = "joserfc" },
-    { name = "jsonref" },
     { name = "jsonschema-path" },
     { name = "mcp" },
     { name = "openapi-pydantic" },
-    { name = "opentelemetry-api" },
-    { name = "packaging" },
-    { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
+    { name = "platformdirs" },
+    { name = "py-key-value-aio", extra = ["disk", "keyring", "memory"] },
+    { name = "pydantic", extra = ["email"] },
+    { name = "pydocket" },
     { name = "pyperclip" },
-    { name = "python-multipart" },
-    { name = "pyyaml" },
-    { name = "starlette" },
-    { name = "uncalled-for" },
+    { name = "python-dotenv" },
+    { name = "rich" },
     { name = "uvicorn" },
-    { name = "watchfiles" },
     { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/35/50/9bb042a2d290ccadb35db3580ac507f192e1a39c489eb8faa167cd5e3b57/fastmcp-2.14.0.tar.gz", hash = "sha256:c1f487b36a3e4b043dbf3330e588830047df2e06f8ef0920d62dfb34d0905727", size = 8232562, upload-time = "2025-12-11T23:04:27.134Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/73/b5656172a6beb2eacec95f04403ddea1928e4b22066700fd14780f8f45d1/fastmcp-2.14.0-py3-none-any.whl", hash = "sha256:7b374c0bcaf1ef1ef46b9255ea84c607f354291eaf647ff56a47c69f5ec0c204", size = 398965, upload-time = "2025-12-11T23:04:25.587Z" },
 ]
 
 [[package]]
@@ -465,15 +442,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e6/dc/be6cbe99670cd6e4ad387123647cb08e0c32975e223f82551e914c5568a6/filelock-3.29.4.tar.gz", hash = "sha256:10cdb3656fc44541cdf30652a93fb10ec6b05325620eb316bd26893e4201538a", size = 63028, upload-time = "2026-06-13T16:12:00.744Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/13/37/a065dc3bd6e49423a6532c642ca7378d3f467b1ef44c2800c937af7f9739/filelock-3.29.4-py3-none-any.whl", hash = "sha256:dac1648087d5115554850d113e7dd8c83ab2d38e3435dde2d4f163847e57b767", size = 42757, upload-time = "2026-06-13T16:11:59.582Z" },
-]
-
-[[package]]
-name = "griffelib"
-version = "2.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/33/e4/8d187ea29c2e30b3a09505c567513077d6117861bde1fbd997a167f262ec/griffelib-2.1.0.tar.gz", hash = "sha256:762a186d2c6fd6794d4ea20d428d597ffb857cb56b66421651cbba15bdd5e813", size = 216234, upload-time = "2026-06-19T12:05:42.278Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e4/d3/5268aeabf2ad82658c4e2ff3a060648d0f02f3926cb53247c0e4d0dab49e/griffelib-2.1.0-py3-none-any.whl", hash = "sha256:cc7b3d2d2865ad0b909fcc38086e3f554b5ea7acbaa7bbb7ecaa3f5dfb7d9f00", size = 142560, upload-time = "2026-06-19T12:05:38.742Z" },
 ]
 
 [[package]]
@@ -538,6 +506,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
+]
+
+[[package]]
+name = "importlib-metadata"
+version = "8.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "zipp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f3/49/3b30cad09e7771a4982d9975a8cbf64f00d4a1ececb53297f1d9a7be1b10/importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb", size = 57107, upload-time = "2025-12-21T10:00:19.278Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/5e/f8e9a1d23b9c20a551a8a02ea3637b4642e22c2626e3a13a9a29cdea99eb/importlib_metadata-8.7.1-py3-none-any.whl", hash = "sha256:5a1f80bf1daa489495071efbb095d75a634cf28a8bc299581244063b53176151", size = 27865, upload-time = "2025-12-21T10:00:18.329Z" },
 ]
 
 [[package]]
@@ -625,17 +605,8 @@ wheels = [
 ]
 
 [[package]]
-name = "jsonref"
-version = "1.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/aa/0d/c1f3277e90ccdb50d33ed5ba1ec5b3f0a242ed8c1b1a85d3afeb68464dca/jsonref-1.1.0.tar.gz", hash = "sha256:32fe8e1d85af0fdefbebce950af85590b22b60f9e95443176adbde4e1ecea552", size = 8814, upload-time = "2023-01-16T16:10:04.455Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/ec/e1db9922bceb168197a558a2b8c03a7963f1afe93517ddd3cf99f202f996/jsonref-1.1.0-py3-none-any.whl", hash = "sha256:590dc7773df6c21cbf948b5dac07a72a251db28b0238ceecce0a2abfa8ec30a9", size = 9425, upload-time = "2023-01-16T16:10:02.255Z" },
-]
-
-[[package]]
 name = "jsonschema"
-version = "4.26.0"
+version = "4.25.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -643,9 +614,9 @@ dependencies = [
     { name = "referencing" },
     { name = "rpds-py" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/69/f7185de793a29082a9f3c7728268ffb31cb5095131a9c139a74078e27336/jsonschema-4.25.1.tar.gz", hash = "sha256:e4a9655ce0da0c0b67a085847e00a3a51449e1157f4f75e9fb5aa545e122eb85", size = 357342, upload-time = "2025-08-18T17:03:50.038Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/9c/8c95d856233c1f82500c2450b8c68576b4cf1c871db3afac5c34ff84e6fd/jsonschema-4.25.1-py3-none-any.whl", hash = "sha256:3fba0169e345c7175110351d456342c364814cfcf3b964ba4587f22915230a63", size = 90040, upload-time = "2025-08-18T17:03:48.373Z" },
 ]
 
 [[package]]
@@ -776,7 +747,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.28.1"
+version = "1.23.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -794,9 +765,9 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a7/a4/d06a303f45997e266f2c228081abe299bbcba216cb806128e2e49095d25f/mcp-1.23.3.tar.gz", hash = "sha256:b3b0da2cc949950ce1259c7bfc1b081905a51916fcd7c8182125b85e70825201", size = 600697, upload-time = "2025-12-09T16:04:37.351Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620, upload-time = "2026-06-26T12:57:27.218Z" },
+    { url = "https://files.pythonhosted.org/packages/32/c6/13c1a26b47b3f3a3b480783001ada4268917c9f42d78a079c336da2e75e5/mcp-1.23.3-py3-none-any.whl", hash = "sha256:32768af4b46a1b4f7df34e2bfdf5c6011e7b63d7f1b0e321d0fdef4cd6082031", size = 231570, upload-time = "2025-12-09T16:04:35.56Z" },
 ]
 
 [[package]]
@@ -937,14 +908,15 @@ wheels = [
 
 [[package]]
 name = "opentelemetry-api"
-version = "1.43.0"
+version = "1.37.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "importlib-metadata" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ae/cc/e4c9584181f86494df0f6bdec1a4f3280c50db44704dc2a407e994fc87bb/opentelemetry_api-1.43.0.tar.gz", hash = "sha256:107d0d03857ea8fc7c5fcbbbd83f800c281f0d560553d61c1d675fccfd1761c1", size = 73476, upload-time = "2026-06-24T15:19:55.323Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/04/05040d7ce33a907a2a02257e601992f0cdf11c73b33f13c4492bf6c3d6d5/opentelemetry_api-1.37.0.tar.gz", hash = "sha256:540735b120355bd5112738ea53621f8d5edb35ebcd6fe21ada3ab1c61d1cd9a7", size = 64923, upload-time = "2025-09-11T10:29:01.662Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/17/83/6dba32b85f31868400440dc7ad2ca1eab94cbbf3a7b0459ed39f8311a9e2/opentelemetry_api-1.43.0-py3-none-any.whl", hash = "sha256:20acf45e9b21851926835292e4045d290acade1edd2ff3de86d2f069687ba1fd", size = 61912, upload-time = "2026-06-24T15:19:35.434Z" },
+    { url = "https://files.pythonhosted.org/packages/91/48/28ed9e55dcf2f453128df738210a980e09f4e468a456fa3c763dbc8be70a/opentelemetry_api-1.37.0-py3-none-any.whl", hash = "sha256:accf2024d3e89faec14302213bc39550ec0f4095d1cf5ca688e1bfb1c8612f47", size = 65732, upload-time = "2025-09-11T10:28:41.826Z" },
 ]
 
 [[package]]
@@ -972,6 +944,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/66/f3/5a20387de9bcd0607871bfc2198ee0e15836da7baa4592ccd7f24c27c986/pathable-0.6.0.tar.gz", hash = "sha256:6404b8b82aef5ff0fd478934137128b99b12212ba35afdde5525ca4f8388ea58", size = 18970, upload-time = "2026-05-19T18:15:11.911Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a2/e8/6d75ffd9784bce2e93d1ae4415649427e39a53bb172d4672b2b59c6f0a7b/pathable-0.6.0-py3-none-any.whl", hash = "sha256:82c4ca6c98c502ad12e0d4e9779b6210afee93c38990988c8c5d1b49bdcdf566", size = 18983, upload-time = "2026-05-19T18:15:10.728Z" },
+]
+
+[[package]]
+name = "pathvalidate"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fa/2a/52a8da6fe965dea6192eb716b357558e103aea0a1e9a8352ad575a8406ca/pathvalidate-3.3.1.tar.gz", hash = "sha256:b18c07212bfead624345bb8e1d6141cdcf15a39736994ea0b94035ad2b1ba177", size = 63262, upload-time = "2025-06-15T09:07:20.736Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/70/875f4a23bfc4731703a5835487d0d2fb999031bd415e7d17c0ae615c18b7/pathvalidate-3.3.1-py3-none-any.whl", hash = "sha256:5263baab691f8e1af96092fa5137ee17df5bdfbd6cff1fcac4d6ef4bc2e1735f", size = 24305, upload-time = "2025-06-15T09:07:19.117Z" },
 ]
 
 [[package]]
@@ -1022,28 +1003,53 @@ wheels = [
 ]
 
 [[package]]
+name = "prometheus-client"
+version = "0.26.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/73/f1334c29c2af4cd9dba6c7817e61b611bd0215e2eb5565c6064a4de18802/prometheus_client-0.26.0.tar.gz", hash = "sha256:04a91bcf94e2cf74a44a1a874d651a2e853ed354b6e822f3b7487751465d5c2b", size = 92910, upload-time = "2026-07-24T19:36:41.893Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/a3/b69efbf4143b5b9859b977770bbbabcc2796b702fa69dc40271e45cd5a56/prometheus_client-0.26.0-py3-none-any.whl", hash = "sha256:fa93d06737aa02bacd05794768508bb97d2fbee28cb3bca04eaae92f0ca953d6", size = 64494, upload-time = "2026-07-24T19:36:40.854Z" },
+]
+
+[[package]]
 name = "py-key-value-aio"
-version = "0.4.5"
+version = "0.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beartype" },
-    { name = "typing-extensions" },
+    { name = "py-key-value-shared" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fb/e2/d689d922894a7ecde73b6daeaf9b13dab5aae06fe6aaaf7514722644d382/py_key_value_aio-0.4.5.tar.gz", hash = "sha256:c6563a2c6abe5da5e20f4f9e875c2a9b425a2244a54fadbf46cf140a9eea45d7", size = 107547, upload-time = "2026-05-27T16:37:08.107Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/93/ce/3136b771dddf5ac905cc193b461eb67967cf3979688c6696e1f2cdcde7ea/py_key_value_aio-0.3.0.tar.gz", hash = "sha256:858e852fcf6d696d231266da66042d3355a7f9871650415feef9fca7a6cd4155", size = 50801, upload-time = "2025-11-17T16:50:04.711Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f6/95/b8ba862968712caa12a19666175334fa979e1f198b896a430adb3bacfe87/py_key_value_aio-0.4.5-py3-none-any.whl", hash = "sha256:ab862adbcb8c72547d1c57821f22cbbb71ab86509039c96f36e914e0336c8dd7", size = 170005, upload-time = "2026-05-27T16:37:06.629Z" },
+    { url = "https://files.pythonhosted.org/packages/99/10/72f6f213b8f0bce36eff21fda0a13271834e9eeff7f9609b01afdc253c79/py_key_value_aio-0.3.0-py3-none-any.whl", hash = "sha256:1c781915766078bfd608daa769fefb97e65d1d73746a3dfb640460e322071b64", size = 96342, upload-time = "2025-11-17T16:50:03.801Z" },
 ]
 
 [package.optional-dependencies]
-filetree = [
-    { name = "aiofile" },
-    { name = "anyio" },
+disk = [
+    { name = "diskcache" },
+    { name = "pathvalidate" },
 ]
 keyring = [
     { name = "keyring" },
 ]
 memory = [
     { name = "cachetools" },
+]
+redis = [
+    { name = "redis" },
+]
+
+[[package]]
+name = "py-key-value-shared"
+version = "0.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beartype" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7b/e4/1971dfc4620a3a15b4579fe99e024f5edd6e0967a71154771a059daff4db/py_key_value_shared-0.3.0.tar.gz", hash = "sha256:8fdd786cf96c3e900102945f92aa1473138ebe960ef49da1c833790160c28a4b", size = 11666, upload-time = "2025-11-17T16:50:06.849Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/e4/b8b0a03ece72f47dce2307d36e1c34725b7223d209fc679315ffe6a4e2c3/py_key_value_shared-0.3.0-py3-none-any.whl", hash = "sha256:5b0efba7ebca08bb158b1e93afc2f07d30b8f40c2fc12ce24a4c0d84f42f9298", size = 19560, upload-time = "2025-11-17T16:50:05.954Z" },
 ]
 
 [[package]]
@@ -1143,6 +1149,30 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440", size = 61715, upload-time = "2026-06-19T13:44:55.02Z" },
+]
+
+[[package]]
+name = "pydocket"
+version = "0.23.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "burner-redis" },
+    { name = "cloudpickle" },
+    { name = "cronsim" },
+    { name = "opentelemetry-api" },
+    { name = "prometheus-client" },
+    { name = "py-key-value-aio", extra = ["memory", "redis"] },
+    { name = "python-json-logger" },
+    { name = "redis" },
+    { name = "rich" },
+    { name = "typer" },
+    { name = "typing-extensions" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+    { name = "uncalled-for" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f8/72/f5a0960249d32a213fb26297a55f842ce8bc90bb19adbf47fefebb9c99da/pydocket-0.23.1.tar.gz", hash = "sha256:136c1cc8b7aa7c4c08ea12431e966ae75eb093bb6ce6e0ac9db3391ba3d6034b", size = 425621, upload-time = "2026-07-20T18:49:24.592Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e6/67/b57ac7cfd2c2f30d58ff2c996591880d200078fc828cbbad8da69d634c0e/pydocket-0.23.1-py3-none-any.whl", hash = "sha256:3da279978fd0d07eb96d4119e1a213de61d6b4acd1792a28bc62e67f3e7e5929", size = 129230, upload-time = "2026-07-20T18:49:23.243Z" },
 ]
 
 [[package]]
@@ -1255,6 +1285,15 @@ wheels = [
 ]
 
 [[package]]
+name = "python-json-logger"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f7/ff/3cc9165fd44106973cd7ac9facb674a65ed853494592541d339bdc9a30eb/python_json_logger-4.1.0.tar.gz", hash = "sha256:b396b9e3ed782b09ff9d6e4f1683d46c83ad0d35d2e407c09a9ebbf038f88195", size = 17573, upload-time = "2026-03-29T04:39:56.805Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/be/0631a861af4d1c875f096c07d34e9a63639560a717130e7a87cbc82b7e3f/python_json_logger-4.1.0-py3-none-any.whl", hash = "sha256:132994765cf75bf44554be9aa49b06ef2345d23661a96720262716438141b6b2", size = 15021, upload-time = "2026-03-29T04:39:55.266Z" },
+]
+
+[[package]]
 name = "python-multipart"
 version = "0.0.32"
 source = { registry = "https://pypi.org/simple" }
@@ -1265,18 +1304,15 @@ wheels = [
 
 [[package]]
 name = "pywin32"
-version = "312"
+version = "311"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2d/41/12fbfd7f36ed2146d8bc9de96c2741296bf0d490b98508496cff322e274c/pywin32-312-cp313-cp313-win32.whl", hash = "sha256:7a27df850933d16a8eabfbaeb73d52b273e2da667f80d70b01a89d1f6828d02c", size = 6370184, upload-time = "2026-06-04T07:49:36.253Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/db/36a78e3403099d31d9746d13fdcde5accc43c1155f375a34d15983a479a7/pywin32-312-cp313-cp313-win_amd64.whl", hash = "sha256:c53e878d15a1c44788082bfe712a905433473aa38f86375b7cf8b45e3acbaaf9", size = 6914298, upload-time = "2026-06-04T07:49:38.876Z" },
-    { url = "https://files.pythonhosted.org/packages/84/37/c1697194092b76de9ed47ca124323f02c57ffc8a45c06f88a3d5acaf01eb/pywin32-312-cp313-cp313-win_arm64.whl", hash = "sha256:59aba5d5940842075343a5ddc6b11f1cdf0d1567fe745290359dfbcc7c2eb831", size = 6727640, upload-time = "2026-06-04T07:49:41.083Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/2b/1f3cded5822fd49c02f40544cbb5f58c7cfd6b1694869fd476cb6170ee97/pywin32-312-cp314-cp314-win32.whl", hash = "sha256:a77a90fbb6881238d2ca9c6fd797b25817f3768fe78d214a90137ff055a75f5b", size = 6468928, upload-time = "2026-06-04T07:49:43.188Z" },
-    { url = "https://files.pythonhosted.org/packages/21/82/3bf86d2e2808902013132e1ce905a7da0da53790f3836c64bf44d55e24f3/pywin32-312-cp314-cp314-win_amd64.whl", hash = "sha256:a4dd3a848290ef724347b19f301045831d8e802fa4464f491b98b1e0a081432e", size = 7024157, upload-time = "2026-06-04T07:49:45.34Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/0e/73f6d6800b4f27655abd9e9f6aaeaefcddb2b946e4674efa2bab184a7f7b/pywin32-312-cp314-cp314-win_arm64.whl", hash = "sha256:9fce94568364e0155e6dfb781ac5d95903be8baf28670632beab1b523f300daa", size = 6839598, upload-time = "2026-06-04T07:49:47.613Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/61/caa39686032d2ebdd04ff0ab5cbe163126c0066d98e00c9018646e42393b/pywin32-312-cp315-cp315-win32.whl", hash = "sha256:5c1fbe4a937a73ae9297384a3da38518cbc694c68ad8a809b2e19acd350f03ed", size = 6471159, upload-time = "2026-06-04T07:49:50.035Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/cd/7e1de64a4a6f69c04214169657ccab0d93a670ea50e35eb8f489d7378249/pywin32-312-cp315-cp315-win_amd64.whl", hash = "sha256:c2f03a0f73f804a13c2735b99392b0cd426bb4f2c4d0178e5ac966a0f21618d5", size = 7025293, upload-time = "2026-06-04T07:49:54.857Z" },
-    { url = "https://files.pythonhosted.org/packages/23/ed/4532e9388e65fa16b46776ef47ad631a64eda1631884488af707666350ed/pywin32-312-cp315-cp315-win_arm64.whl", hash = "sha256:a8597d28f267b39074aef51fa593530082b39cbe5a074226096857b1fed2dfb9", size = 6840337, upload-time = "2026-06-04T07:49:57.531Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/be/3fd5de0979fcb3994bfee0d65ed8ca9506a8a1260651b86174f6a86f52b3/pywin32-311-cp313-cp313-win32.whl", hash = "sha256:f95ba5a847cba10dd8c4d8fefa9f2a6cf283b8b88ed6178fa8a6c1ab16054d0d", size = 8705700, upload-time = "2025-07-14T20:13:26.471Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/28/e0a1909523c6890208295a29e05c2adb2126364e289826c0a8bc7297bd5c/pywin32-311-cp313-cp313-win_amd64.whl", hash = "sha256:718a38f7e5b058e76aee1c56ddd06908116d35147e133427e59a3983f703a20d", size = 9494700, upload-time = "2025-07-14T20:13:28.243Z" },
+    { url = "https://files.pythonhosted.org/packages/04/bf/90339ac0f55726dce7d794e6d79a18a91265bdf3aa70b6b9ca52f35e022a/pywin32-311-cp313-cp313-win_arm64.whl", hash = "sha256:7b4075d959648406202d92a2310cb990fea19b535c7f4a78d3f5e10b926eeb8a", size = 8709318, upload-time = "2025-07-14T20:13:30.348Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/31/097f2e132c4f16d99a22bfb777e0fd88bd8e1c634304e102f313af69ace5/pywin32-311-cp314-cp314-win32.whl", hash = "sha256:b7a2c10b93f8986666d0c803ee19b5990885872a7de910fc460f9b0c2fbf92ee", size = 8840714, upload-time = "2025-07-14T20:13:32.449Z" },
+    { url = "https://files.pythonhosted.org/packages/90/4b/07c77d8ba0e01349358082713400435347df8426208171ce297da32c313d/pywin32-311-cp314-cp314-win_amd64.whl", hash = "sha256:3aca44c046bd2ed8c90de9cb8427f581c479e594e99b5c0bb19b29c10fd6cb87", size = 9656800, upload-time = "2025-07-14T20:13:34.312Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/d2/21af5c535501a7233e734b8af901574572da66fcc254cb35d0609c9080dd/pywin32-311-cp314-cp314-win_arm64.whl", hash = "sha256:a508e2d9025764a8270f93111a970e1d0fbfc33f4153b388bb649b7eec4f9b42", size = 8932540, upload-time = "2025-07-14T20:13:36.379Z" },
 ]
 
 [[package]]
@@ -1322,6 +1358,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "redis"
+version = "8.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/c3/928b290c2c0ca99ab96eea5b4ff8f30be8112b075301a7d3ba214a3c8c12/redis-8.0.1.tar.gz", hash = "sha256:afc5a7a2f5a084f5b1880dec548dd45be17db7e43c82a30d84f952aefb05cfb0", size = 5114170, upload-time = "2026-06-23T14:52:37.728Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/0a/c2345ebf1ebe70840ce3f6c6ee612f8fa749cfbd1b03069c53bf0c62aaad/redis-8.0.1-py3-none-any.whl", hash = "sha256:47daa35a058c23468d6437f17a8c76882cb316b838ef763036af99b96cedd743", size = 502406, upload-time = "2026-06-23T14:52:36.137Z" },
 ]
 
 [[package]]
@@ -1761,6 +1806,15 @@ wheels = [
 ]
 
 [[package]]
+name = "tzdata"
+version = "2026.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/ff/5a28bdfd8c3ebec42564ac7d0e54ca3db65044a9314a97f9564fa7a1e926/tzdata-2026.3.tar.gz", hash = "sha256:4a1518b8993086a7982523e071643f3c0e5f213e75b21318e78bcabfff9d1415", size = 198674, upload-time = "2026-07-10T08:50:37.887Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/6d/b53b99a9f2766d095985947a5782f1702cabb129a34f7a802d7197af832f/tzdata-2026.3-py2.py3-none-any.whl", hash = "sha256:dc096730c87af6cab1b171c9d532be840741ff5d459015e7f6947bd7d7e54931", size = 348168, upload-time = "2026-07-10T08:50:36.46Z" },
+]
+
+[[package]]
 name = "uncalled-for"
 version = "0.3.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1804,78 +1858,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/66/3e/4d08c5903b2c0c70cad583c170cc4a663fc6a61e2ad00b711fcda61358cd/vulture-2.16.tar.gz", hash = "sha256:f8d9f6e2af03011664a3c6c240c9765b3f392917d3135fddca6d6a68d359f717", size = 52680, upload-time = "2026-03-25T14:41:27.141Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f5/be/f935130312330614811dae2ea9df3f395f6d63889eb6c2e68c14507152ee/vulture-2.16-py3-none-any.whl", hash = "sha256:6e0f1c312cef1c87856957e5c2ca9608834a7c794c2180477f30bf0e4cc58eee", size = 26993, upload-time = "2026-03-25T14:41:26.21Z" },
-]
-
-[[package]]
-name = "watchfiles"
-version = "1.2.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/cd/41/5e1a4bb12aac5f1493fa1bdc11154eca3b258ca4eba65d39c473fe19d8e9/watchfiles-1.2.0.tar.gz", hash = "sha256:c995fba777f1ea992f090f9236e9284cf7a5d1a0130dd5a3d82c598cacd76838", size = 108252, upload-time = "2026-05-18T04:32:04.251Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d1/4d/70a7feced9f87e2ff26dba42667290f41694fc64646c67261fbb8cab5d5c/watchfiles-1.2.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:01ea8d66f0693b9b60a6541c8d10263091ca9a9060d242f3c1f3143f9aad2c98", size = 399730, upload-time = "2026-05-18T04:31:38.162Z" },
-    { url = "https://files.pythonhosted.org/packages/31/3a/0da302f2307aee316922806ebd5726c542cbd787c938271cf14a074c7daf/watchfiles-1.2.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7ba0480b9a74af058f43b337e937a451e109295c420916d68ad24e3dc02f5e44", size = 392842, upload-time = "2026-05-18T04:30:27.051Z" },
-    { url = "https://files.pythonhosted.org/packages/db/ef/d5bdb705c224dbc256aa0c1ec47bf4e61ec52558f2afb44a71a1fe4d7015/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4f34e26a19f91f710c08e0183429f0d1d15df734e6bc78c31e77b9ea9c433658", size = 452989, upload-time = "2026-05-18T04:31:11.945Z" },
-    { url = "https://files.pythonhosted.org/packages/71/29/5495f2c1661949ef7a35e4d71111d129cfe7606414a26887a919d0a55406/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b4e77f6a55f858504069abd35d336a637555c09bca453dde1ee1e5ada8a6a1fb", size = 458978, upload-time = "2026-05-18T04:30:52.606Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/8c/7f9c07c433811c2fffd93e13fdfb7135de9aab5f2ae41be08960fa0047dc/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0cb4d80e212f116474a545c21c912b445f16bb0cef9e6a73a498164223e14e2f", size = 490248, upload-time = "2026-05-18T04:31:36.003Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/11/d93632febc52fbc21be90231bb7c17fd5387f46c9076fd40a5f9c2ae6910/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b974946a10af379d425e2eef5b62f5c6ebeaccf91d45eaad6f5b27ecd4f91aa0", size = 571847, upload-time = "2026-05-18T04:31:10.862Z" },
-    { url = "https://files.pythonhosted.org/packages/55/b4/383173e73aabb07ad1d9c7aa859d95437ac46a6d6a1e11005facda0c9d19/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:86bc13c25a8d1fcd70b51d0ce7c9b65e90de5666fcbfd3e34957cc73ee19aeb5", size = 465974, upload-time = "2026-05-18T04:30:17.006Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/6c/89b1a230a78f57c52dd8893adb1f92f94411721b6ec12596c56d98c74356/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ca148d73dea36c9763aaa351e4d7a51780ec1584217c45276f4fe8239c768b71", size = 454782, upload-time = "2026-05-18T04:30:35.656Z" },
-    { url = "https://files.pythonhosted.org/packages/24/62/1732118367cfff0a9fce3bf62ff4bfded09ef5df21d9d446b858b3f70a96/watchfiles-1.2.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:c525543d91961c6955b2636b308569e84a1d1c5f5f2932041ab9ef46422f43e3", size = 465182, upload-time = "2026-05-18T04:30:20.846Z" },
-    { url = "https://files.pythonhosted.org/packages/28/96/716f7e5f51339bf22963f3345f9f27d7f3b30e2eadc597e257c881dd3c53/watchfiles-1.2.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:a204794696ffb8f9b10fba6f7cb5216d42f3b2b71860ccac6b6e42f5f10973b0", size = 629841, upload-time = "2026-05-18T04:31:05.397Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/fe/c40783950fd771ccf66ab3ec2722d188a9af1c7f96c6e811f36e40c6e03f/watchfiles-1.2.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:10d86db20695afe7997ac9e1717637d6714a8d0220458c33f3d2061f54cec427", size = 658028, upload-time = "2026-05-18T04:31:48.22Z" },
-    { url = "https://files.pythonhosted.org/packages/71/72/4508db1856d1d87fcbb3b63f4839bab1b5682cb0e8d224d122263c09654a/watchfiles-1.2.0-cp313-cp313-win32.whl", hash = "sha256:eb283ee99e21ad6443c8cdb06ac5b34b1308c329cbdf03fa02b445363714c799", size = 275183, upload-time = "2026-05-18T04:30:59.57Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/36/14b76ca57652e5cc5fd1c11f32a261292c08a0d19a00351013c2549cbfb2/watchfiles-1.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:a0f27f01bee51861392bb6b7c4fdb290b27d1eb194e9e28788d68102a0e898d9", size = 288059, upload-time = "2026-05-18T04:32:07.937Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/8d/0a85e395398d8d20fadfe5c5d32c726eee17a519e78fb356f2cf7531bffe/watchfiles-1.2.0-cp313-cp313-win_arm64.whl", hash = "sha256:3651aa7058595e9cfb75d35dd5ada2bf9f48a5b8a0f3562821d3e210c507e077", size = 280186, upload-time = "2026-05-18T04:31:54.484Z" },
-    { url = "https://files.pythonhosted.org/packages/37/68/36db056f1fdcc5f07302f56e631774d6835bcd6fa3ace402304621d5f9e5/watchfiles-1.2.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:faea288b6f0ab1902ef08f4ca6de005dccf856c4e0c4f21b8c5fce02d90a1b08", size = 399031, upload-time = "2026-05-18T04:30:44.576Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/64/01a9d6f66a82a5c101ce939274106cc72759d62427e153f01edd2b9f87c2/watchfiles-1.2.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:01859b11fd9fbca670f4d5da00fbac282cfea9bd67a2125d8b2833a3b5617ea9", size = 391205, upload-time = "2026-05-18T04:30:25.413Z" },
-    { url = "https://files.pythonhosted.org/packages/84/2c/0a44fe058cb4bb7b8ede6b6670698bbb7c0400740e378d00022189b7b31d/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fff610d7bb2256a317bb1e96f0d7862c7aa8076733ee5df0fd41bbe76a24a4f4", size = 451892, upload-time = "2026-05-18T04:32:14.005Z" },
-    { url = "https://files.pythonhosted.org/packages/67/a1/351e0d56cd35e6488b5c8b4fb11a809a5bc923e8fe8fed9faf8920be0c89/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b141a4891c995a039cd89e9a49e62df1dc8a559a5d1a6e4c7106d16c12777a55", size = 458867, upload-time = "2026-05-18T04:31:22.279Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/7d/9d09605187f1b838998624049fcf8bf47b73c1a3b76901fcac1782f62277/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f22943b7770483f6ea0721c6b11d022947a98eb0acae14694de034f4d0d38925", size = 490217, upload-time = "2026-05-18T04:31:43.657Z" },
-    { url = "https://files.pythonhosted.org/packages/60/5d/a17a16eccb182f04188cd308ec24b1a71a9b5c4e7098269cf35d9fa56d02/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1bc6195825b7dcd217968bb1f801a60fd4c16e8eeab5bedc7fe917d7d5995ab4", size = 571458, upload-time = "2026-05-18T04:32:11.875Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/3d/4dd457062083ab1938e5dfd45032eb425cee2ac817287ca8ff4356183e5d/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d4a4b147f5dca2a5d325a06a832fb43f345751adfbc63204aec30e0d9ca965a2", size = 464707, upload-time = "2026-05-18T04:30:43.492Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/71/ea8c57b128f5383de74d0c7d2d9c57ad7c9a65a930c451bd25d524b295b7/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4543579a9bdb0c9560039b4ffddbdb39545707659fbc430ce4c10f3f68d557f9", size = 454663, upload-time = "2026-05-18T04:30:16.061Z" },
-    { url = "https://files.pythonhosted.org/packages/53/fd/2e812bf938406d7db351f0703ddd3fc6c061cf30d96153a77bc79a943a44/watchfiles-1.2.0-cp313-cp313t-manylinux_2_31_riscv64.whl", hash = "sha256:20aa0e708b920bde876a4aa82dc7dd6ebea228a63a67cda6632c2fc87b787efa", size = 463537, upload-time = "2026-05-18T04:31:44.9Z" },
-    { url = "https://files.pythonhosted.org/packages/86/56/d17a7f1dd1bc3035f1072694a551301272f1739c2d8e319c927cb9e29b38/watchfiles-1.2.0-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:d413349d565dab74297f2a63e84a097936be69bf8f3b3801f27f380e32040f44", size = 629194, upload-time = "2026-05-18T04:31:14.141Z" },
-    { url = "https://files.pythonhosted.org/packages/be/06/f1ff66bf5cae50aa4062779a0ecd0bbaf15e466195719074078947d9a17d/watchfiles-1.2.0-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:f28b2725eb8cce327b9b3ab02415c853011dc55c95832fe90de6bc56f5315f72", size = 656194, upload-time = "2026-05-18T04:31:47.14Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/54/a9c7ea9a82a4ac65e7004c0a03920b5cdd2f9c3b678757d9cd425aa51d53/watchfiles-1.2.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:b8c8358484d5fa12ef34f05b7f4168eaf1932f408725ff6d023c33ec17bd79d4", size = 400205, upload-time = "2026-05-18T04:32:05.153Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/5d/c9ab3534374a4a67450696905d6ef16a04405448b8dc52bd752ae50423d4/watchfiles-1.2.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9f04b092229ad2c50126dd3c922c8822e51e605993764a33058d4a791ab42281", size = 392508, upload-time = "2026-05-18T04:30:54.849Z" },
-    { url = "https://files.pythonhosted.org/packages/26/ca/1ad30103535cf0cecd7b993e8d50edc5351b1820e38f2d22e3df58962feb/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7a7ce236284f002a156f70add88efe5c70879cccbb658be0822c54b1306fc09d", size = 452448, upload-time = "2026-05-18T04:30:53.727Z" },
-    { url = "https://files.pythonhosted.org/packages/37/a1/ceee2cdf2afbd715fa07758d39c9859513eae411b23196f7fd039e5feedd/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b9909cc2b48468b575eefa944919e1fe8a36c5849d5c7c168f80a8c1db69398e", size = 459605, upload-time = "2026-05-18T04:30:23.312Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/f6/421e30fd1cb3907a84ed92ab3f1983e37ba2dca015e9a894a048418417a2/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0a37faaed405c67e28e6be45a1fa4f206ef5a2860f27c237db9fa30704c38242", size = 490757, upload-time = "2026-05-18T04:30:47.358Z" },
-    { url = "https://files.pythonhosted.org/packages/41/b0/55ed1b97ed08be7bba6f9a541cac15f2a858e1d74d2b07b6da70a82aab00/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9649193aa27bd9ff2e80ff29bfaa93085496c7a3a377592823cc58b77ee88add", size = 568672, upload-time = "2026-05-18T04:30:38.915Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/cf/d8ae8a80dd7bafab395ea7681c10237311bbf34d37704a8c744e7cf31fc7/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4e4ff8e37f99cf1da89e255e07c9c4b37c214038c4283707bdec308cb1b0ea1f", size = 464197, upload-time = "2026-05-18T04:30:09.914Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/8a/3076c496ca8dafe0e8cd03fcebdfc47be4b1174b4e5b24ff6e396e6b3af2/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:054dc20fd2e3132b4c3883b4a00d72fd6e1f56fdaf89fccd12e8057d74cd74d7", size = 453181, upload-time = "2026-05-18T04:30:14.829Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/10/9745e17c98e7b8a86454df0a3c7b5686bd650383f1e9f26e4ebcbd6cc0c0/watchfiles-1.2.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:e140ed30ebde76796b686e67c182cff10ea2fbab186fafd1560f74bb5a473a6e", size = 465109, upload-time = "2026-05-18T04:30:28.123Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/95/8ef4a95481d3e0cb52d62a06fa6e972e81424be2d9698b91a2fecca9904c/watchfiles-1.2.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:bb7e52ecf68ba46d22df23467b87cffeb2146908aa523ebfe803019618cfda06", size = 630653, upload-time = "2026-05-18T04:31:49.304Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/e4/3b3bf36b0f829b50c6ebcb8d031583863c59f923d6a6af3d485e470d0fac/watchfiles-1.2.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:23282a321c8baf9b3a3c4afff673f9fe65eb7fdc2338d765ccad9d3d1916a5ba", size = 657838, upload-time = "2026-05-18T04:31:06.497Z" },
-    { url = "https://files.pythonhosted.org/packages/21/b1/6cbbb50c1f3002ab568777d44aa21206dfb8807a840990c4037523b51812/watchfiles-1.2.0-cp314-cp314-win32.whl", hash = "sha256:c0db965c5f79aa49fe672d297cf1febc5ad149b658594944f49a54a2b96270a7", size = 275108, upload-time = "2026-05-18T04:30:06.891Z" },
-    { url = "https://files.pythonhosted.org/packages/92/45/190ce6db8dcb4536682cf75d3889ff1a27182a58cb519d343cb6d9ea63d8/watchfiles-1.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:71283b39fd17e5408eb123bd37aeecfd9d54c81fc184421943208aadb879d103", size = 288441, upload-time = "2026-05-18T04:32:12.901Z" },
-    { url = "https://files.pythonhosted.org/packages/74/0d/3eae1c2313ab08378431d907c3f8095ecca00f3eda33111cf4f0f2591799/watchfiles-1.2.0-cp314-cp314-win_arm64.whl", hash = "sha256:c5c19526f4e54a00f2666a6c0e9e40d582c09e865055ea7378bf0009aab857b3", size = 280684, upload-time = "2026-05-18T04:31:26.902Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/75/fb64e6c25d6b5ca636d03df34ffb1c6e9873303e76d27967e045f8df088f/watchfiles-1.2.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:d73a585accffa5ae39c17264c36ec3166d2fad7000c780f5ef83b2722afb9dd2", size = 398857, upload-time = "2026-05-18T04:32:17.108Z" },
-    { url = "https://files.pythonhosted.org/packages/73/4e/9f7adf01754cbf81843722ccfec169d8f26c69778281a302855cecd2ee08/watchfiles-1.2.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ae99b14c5f21e026e0e9d96f40e07d8570ebee6cafd9d8fc318354606daa7a28", size = 392413, upload-time = "2026-05-18T04:31:07.911Z" },
-    { url = "https://files.pythonhosted.org/packages/47/c8/bec626bcc2d69f44b9acb24ce7d60ed7b16b73628eea747fcbd169d8edda/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4429f3b105524a10b72c3a819b091c495d2811d419c1e1e8df773a5a5974f831", size = 452409, upload-time = "2026-05-18T04:31:20.142Z" },
-    { url = "https://files.pythonhosted.org/packages/00/b7/b6362068e81e7c556d155a34c35d40ac3ef42d747b06d7f6e5bf58e359c2/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:43d818978d06062d9b22c4fab2ebe44cf5213d42dc8e62bda8c2760cfa2eeb33", size = 458827, upload-time = "2026-05-18T04:32:06.219Z" },
-    { url = "https://files.pythonhosted.org/packages/67/f8/9a813fa42afb1e0b4625e75f0479826644d3ee8dc287e093799bc01f390c/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b9f732dc58b2dbe69e464ccf8fff7a03b0dd0be439da4c0720d3558527d3d6b4", size = 490104, upload-time = "2026-05-18T04:31:56.034Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/bf/27dfb6094ca4c9aad21298b5525b6c53cb36121ee454331d05161e58d130/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8f200104103feb097de4cab8fe4f5dd18a2026934c7dea98c55a2f5fd6d5a33b", size = 571360, upload-time = "2026-05-18T04:31:57.133Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/39/44a096d67270ea93df91d33877dbe91fbda3aa4f8ec2edf799d93eda8736/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:63ac26eefbf4af1741247d6fb68b11c49a25b2f7413fbd318a83a12aaa9cf666", size = 464644, upload-time = "2026-05-18T04:30:57.33Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/80/c7472203bad6268e3ef1ad260739704847898938ad7ea8b63a5131f46b50/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c4997d4e4a55f0d02b6cde327322daf3a0400e5df6c6b15948994bf72497925", size = 454771, upload-time = "2026-05-18T04:30:48.736Z" },
-    { url = "https://files.pythonhosted.org/packages/51/cf/3b10b268b4b7f0fc26e9debb5eef1998b515887840f444cd3ec80c688755/watchfiles-1.2.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:4c887eba18b7945ac73067a8b4a66f21cd46c2539b2bc68588f7be6c7eb6d26b", size = 463494, upload-time = "2026-05-18T04:31:33.826Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/3e/a4302545cd589262a0dc7d140e86f7688eba3f9c72776c27f7e23b8864c4/watchfiles-1.2.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:3416ff151bb6b5a8d8d11664974fbef4d9305b9b2957839ab5a270468fd8df30", size = 629383, upload-time = "2026-05-18T04:31:15.596Z" },
-    { url = "https://files.pythonhosted.org/packages/db/99/d5649df0a9a410d45b7c882304d0b790903ac9b6e8f2cfd12114e0c6b9f2/watchfiles-1.2.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:0e831a271c035d89789cffc386b6aa1375f39f1cd25eb7ca0997e4970d152fc5", size = 656093, upload-time = "2026-05-18T04:31:58.707Z" },
-    { url = "https://files.pythonhosted.org/packages/92/b9/362702539275019a54dd2e94511b31a9b89c5f9e6a21966de7eb692549fc/watchfiles-1.2.0-cp315-cp315-macosx_10_12_x86_64.whl", hash = "sha256:37a6721cdf3f65dbb13aa9503510ccb4451603ac837e44d265d7992a597e1374", size = 400109, upload-time = "2026-05-18T04:31:16.879Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/75/71d5ba62db781e5587bded1d944c675374bc4aa37ff33d5018d98e8b6538/watchfiles-1.2.0-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:2b37d10b5a63bd4d87e18472d80fa525bd670586fae62e5dd580452764879b65", size = 392167, upload-time = "2026-05-18T04:31:28.058Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/01/c66dd95d0423fe30d31820e2d1d5bda773764131bbb6ac0cb1cf303ac328/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0a105bc2283f67e8fbec74253ec2d94925de92ed72c0393f1206bf326b7b7b69", size = 452372, upload-time = "2026-05-18T04:31:00.836Z" },
-    { url = "https://files.pythonhosted.org/packages/91/15/2fe99557e72f85627c6a8eed50d889e8d101623e060a22ad75b875cb932d/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5327989a465505f05cfe06f04fa9d0c2fd5432bb243e10e6f012b1bdca3c8579", size = 459596, upload-time = "2026-05-18T04:31:34.96Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/23/d4acfa0023367428ed48351b3b9b267893037b6cadae55620c61c24bcfd4/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ecb47f183a8025b2aa18b546725c3657e542112ae9c0613a2af79b4fa8d04ad7", size = 490869, upload-time = "2026-05-18T04:31:59.923Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/5f/3164cbdce06c9fb95c4f7b9e2f9760b5e2797af43a9ecc317ef42a23a278/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8520a4ab0e37f770afc34459c4f8f7019e153f9124dc101c15538365875d1ab2", size = 571641, upload-time = "2026-05-18T04:32:00.948Z" },
-    { url = "https://files.pythonhosted.org/packages/41/e6/85d3731c55e65cd7690f3f803d24c139588aaf863e4bf2148fe7a7fa1a19/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:71cd71740ed2c15211ebb237ced4e39a1cdf6f80566e5fe95428da1626f4fde6", size = 464444, upload-time = "2026-05-18T04:30:34.298Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/7d/562641012b8b09872742c3b8adf9629ec479fd78f8d68ae4a0c13da8add6/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f88af53d6ddaf72179ef613ddc905e6f4785f712b49b80b3bef9f3525e6194b4", size = 453593, upload-time = "2026-05-18T04:31:23.464Z" },
-    { url = "https://files.pythonhosted.org/packages/56/fe/cb8ef3d6f929d14158fdaaad9925985b7310abc9384dcd4d82dd0016fb59/watchfiles-1.2.0-cp315-cp315-manylinux_2_31_riscv64.whl", hash = "sha256:cee9d5efd929efdac5f7e58f72b3376f676b64050a91c5b99a7094c5b2317488", size = 465096, upload-time = "2026-05-18T04:31:30.384Z" },
-    { url = "https://files.pythonhosted.org/packages/25/91/80908e835e100527a9267147b08c0eee1fa6ab0ffec15edc04d1d44885f7/watchfiles-1.2.0-cp315-cp315-musllinux_1_1_aarch64.whl", hash = "sha256:b718bf356bbc15e559bd8ef41782b573b8ae0e3f177ab244b440568d7ea02cfb", size = 630638, upload-time = "2026-05-18T04:30:49.89Z" },
-    { url = "https://files.pythonhosted.org/packages/46/4b/95ab2f256bb4af3cb2eb23b9317bda984ee6e0f11733a5c004a6c95b06e3/watchfiles-1.2.0-cp315-cp315-musllinux_1_1_x86_64.whl", hash = "sha256:922c0e019fe68b3ae392965a766b02a71ba1168c932cebc3733cd52c5fe5b377", size = 657684, upload-time = "2026-05-18T04:31:32.027Z" },
 ]
 
 [[package]]
@@ -1940,4 +1922,13 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/10/b3/0bf174ab6ceedb31d9af462073b5339c894b2084a27d42cb9f0906050d76/zensical-0.0.33-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:90daaf512b0429d7b9147ad5e6085b455d24803eff18b508aed738ca65444683", size = 12975233, upload-time = "2026-04-14T11:08:12.535Z" },
     { url = "https://files.pythonhosted.org/packages/a9/27/7cc3c2d284698647f60f3b823e0101e619c87edf158d47ee11bf4bfb6228/zensical-0.0.33-cp310-abi3-win32.whl", hash = "sha256:2701820597fe19361a12371129927c58c19633dcaa5f6986d610dce58cecd8c4", size = 12012664, upload-time = "2026-04-14T11:08:14.977Z" },
     { url = "https://files.pythonhosted.org/packages/25/0b/6be5c2fdaf9f1600577e7ba5e235d86b72a26f6af389efb146f978f76ac3/zensical-0.0.33-cp310-abi3-win_amd64.whl", hash = "sha256:a5a0911b4247708a55951b74c459f4d5faec5daaf287d23a2e1f0d96be1e647f", size = 12206255, upload-time = "2026-04-14T11:08:17.375Z" },
+]
+
+[[package]]
+name = "zipp"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/d8/eab98a517c14134c0b2eb4e2387bc5f457334293ec5d2dd3857ec2966802/zipp-4.1.0.tar.gz", hash = "sha256:4cb57381f544315db7688e976e922a2b18cdb513d21cc194eb42232ba2a3e602", size = 26214, upload-time = "2026-05-18T20:08:57.967Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/13/547360d81e6d88d58492968ffda9f9542854f11310ee556fef14260cc886/zipp-4.1.0-py3-none-any.whl", hash = "sha256:25ad4e16390cd314347dd8f1de67a2ac538ae658ed4ab9db16029c07c188e97f", size = 10238, upload-time = "2026-05-18T20:08:57.045Z" },
 ]


### PR DESCRIPTION
## Summary

Closes #28, #29, #30 — adds three new analyzers following the existing Ruff/ty/Vulture/Biome pattern (subprocess wrapper → Pydantic models → `@mcp.tool()`):

- **`semgrep-check`** — security/SAST scanning via [Semgrep](https://semgrep.dev/), with CWE/OWASP metadata. Default `config="auto"` (network, Semgrep registry), with an optional override parameter for offline/custom rulesets.
- **`actionlint-check`** — GitHub Actions workflow linting via [actionlint](https://github.com/rhysd/actionlint), stdin-based like Biome.
- **`gitleaks-scan`** — secret scanning via [gitleaks](https://github.com/gitleaks/gitleaks). Always runs with `--redact` — raw secret values are never returned, only the literal string `"REDACTED"`.

### Notable design decision

Semgrep is **not** a `pyproject.toml` dependency. Adding it there was found to pin `mcp==1.23.3` exactly (Semgrep bundles its own MCP integration), which downgraded this project's own `mcp`/`fastmcp` resolution. Instead, `SemgrepAnalyzer` mirrors Biome's discovery pattern: tries `semgrep` on `PATH` first, falls back to `uvx semgrep` (~1s warm-cache overhead, negligible next to Semgrep's own scan time). No CI install step is needed for it — `astral-sh/setup-uv@v6` already provides `uvx`.

actionlint and gitleaks are Go binaries with no PyPI/npm equivalent — installed in CI via pinned release-binary downloads (`v1.7.12` / `v8.30.1`), matching the existing Biome/Node.js CI pattern. Both are excluded from `config://analyzer-versions` (same as Biome), since neither is `importlib.metadata`-discoverable.

### Verified against real binaries (not just mocks)

- actionlint's exact JSON output shape and exit codes (0/1/2/3) spot-checked against a live `v1.7.12` build.
- Semgrep's exit-code contract confirmed: it exits `0` whether or not findings exist, and `--metrics=off` cannot be combined with `--config auto` (Semgrep errors out) — only appended for non-`"auto"` configs.
- gitleaks' `--redact` behavior confirmed against a real PEM private-key fixture — `Match`/`Secret` are replaced with `"REDACTED"` in the JSON report itself, not just console logs.
- End-to-end MCP tool calls exercised live (including a real Semgrep registry call for `config="auto"`) — all three tools return correct, well-formed results.

## Test plan

- [x] `uv run pytest` — 225 tests, 100% coverage (`--cov-fail-under=100`)
- [x] `uv run ruff check` / `uv run ruff format --check` / `uv run ty check` — all clean
- [x] `uv tool run pre-commit run --all-files` — all hooks pass, including the new `semgrep`/`actionlint`/`gitleaks` hooks
- [x] Live end-to-end MCP tool calls against real binaries (Semgrep, actionlint, gitleaks) — verified correct findings and secret redaction
- [x] `config://analyzer-versions` and `docs://analyzers/overview` resources confirmed to reflect the three new tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)